### PR TITLE
converts hyphen var names to underscores for access

### DIFF
--- a/django_cotton/tests/inline_test_case.py
+++ b/django_cotton/tests/inline_test_case.py
@@ -49,7 +49,7 @@ class CottonInlineTestCase(TestCase):
         super().tearDownClass()
 
     def tearDown(self):
-        """Clear cache between tests"""
+        """Clear cache between tests so that we can use the same file names for simplicity"""
         cache.clear()
 
     def create_template(self, name, content):

--- a/django_cotton/tests/inline_test_case.py
+++ b/django_cotton/tests/inline_test_case.py
@@ -3,6 +3,7 @@ import sys
 import shutil
 import tempfile
 
+from django.core.cache import cache
 from django.urls import path
 from django.test import override_settings
 from django.views.generic import TemplateView
@@ -46,6 +47,10 @@ class CottonInlineTestCase(TestCase):
         shutil.rmtree(cls.temp_dir, ignore_errors=True)
         del sys.modules[cls.url_module_name]
         super().tearDownClass()
+
+    def tearDown(self):
+        """Clear cache between tests"""
+        cache.clear()
 
     def create_template(self, name, content):
         """Create a template file in the temporary directory and return the path"""

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -34,13 +34,8 @@ class InlineTestCase(CottonInlineTestCase):
         self.create_template(
             "view.html",
             """
-            <c-component x-data="{
-                attr1: 'im an attr',
-                var1: 'im a var',
-                method() {
-                    return 'im a method';
-                }
-            }" />
+<c-component x-data="{
+}" />
             """,
         )
 
@@ -53,12 +48,7 @@ class InlineTestCase(CottonInlineTestCase):
 
             self.assertTrue(
                 """{
-                attr1: 'im an attr',
-                var1: 'im a var',
-                method() {
-                    return 'im a method';
-                }
-            }"""
+}"""
                 in response.content.decode()
             )
 

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -36,6 +36,8 @@ class InlineTestCase(CottonInlineTestCase):
             "view.html",
             """
 <c-component x-data="{
+test
+test
 }" />
             """,
         )
@@ -48,8 +50,8 @@ class InlineTestCase(CottonInlineTestCase):
             response = self.client.get("/view/")
 
             self.assertTrue(
-                """{
-}"""
+                """test
+test"""
                 in response.content.decode()
             )
 

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -22,6 +22,7 @@ class InlineTestCase(CottonInlineTestCase):
         # Override URLconf
         with self.settings(ROOT_URLCONF=self.get_url_conf()):
             response = self.client.get("/view/")
+            print(response.content.decode())
             self.assertContains(response, '<div class="i-am-component">')
             self.assertContains(response, "Hello, World!")
 

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -22,7 +22,6 @@ class InlineTestCase(CottonInlineTestCase):
         # Override URLconf
         with self.settings(ROOT_URLCONF=self.get_url_conf()):
             response = self.client.get("/view/")
-            print(response.content.decode())
             self.assertContains(response, '<div class="i-am-component">')
             self.assertContains(response, "Hello, World!")
 
@@ -35,10 +34,13 @@ class InlineTestCase(CottonInlineTestCase):
         self.create_template(
             "view.html",
             """
-<c-component x-data="{
-test
-test
-}" />
+            <c-component x-data="{
+                attr1: 'im an attr',
+                var1: 'im a var',
+                method() {
+                    return 'im a method';
+                }
+            }" />
             """,
         )
 
@@ -50,8 +52,13 @@ test
             response = self.client.get("/view/")
 
             self.assertTrue(
-                """test
-test"""
+                """{
+                attr1: 'im an attr',
+                var1: 'im a var',
+                method() {
+                    return 'im a method';
+                }
+            }"""
                 in response.content.decode()
             )
 


### PR DESCRIPTION
When we want to explicitly access attribute as a var which has '-' hyphens, it will be accessible by the snake case form. i.e.

```html
<c-component x-data="{}" />
```

```
{{ x_data }}
```