### PR TITLE
Made the template directory customizable

### DIFF
--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -228,7 +228,7 @@ class CottonTemplateProcessor:
 
             component_key = tag.name[2:]
             component_path = component_key.replace(".", "/").replace("-", "_")
-            opening_tag = f"{{% cotton_component {'cotton/{}.html'.format(component_path)} {component_key} "
+            opening_tag = f"{{% cotton_component {'{}/{}.html'.format(settings.COTTON_DIR if hasattr(settings, 'COTTON_DIR') else 'cotton', component_path)} {component_key} "
 
             # Store attributes that contain template expressions, they are when we use '{{' or '{%' in the value of an attribute
             expression_attrs = []


### PR DESCRIPTION
Hi!

I really like this package and what it attempts to do. I came from a Laravel background, and the sheer lack of server-side template components like this really made it difficult to get into Django's view layer. 

This pull request makes the template directory customizable. By setting the `COTTON_DIR` attribute to a value, this will override the default `cotton` path. This change would let the directory be named `components` for example.