### PR TITLE
fixed attributes with leading or trailing quotes

### DIFF
--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -105,7 +105,9 @@ class CottonTemplateProcessor:
         content = self._replace_syntax_with_placeholders(content)
         content = self._compile_cotton_to_django(content, component_key)
         content = self._replace_placeholders_with_syntax(content)
-        return self._revert_bs4_attribute_empty_attribute_fixing(content)
+        content = self._revert_bs4_attribute_empty_attribute_fixing(content)
+
+        return content
 
     def _replace_syntax_with_placeholders(self, content):
         """# replace {% ... %} and {{ ... }} with placeholders so they dont get touched

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -57,7 +57,9 @@ class CottonComponentNode(Node):
         attrs = {}
 
         for key, value in self.kwargs.items():
-            value = value.strip("'\"")
+            # strip single or double quotes only if both sides have them
+            if value and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
 
             if key.startswith(":"):
                 key = key[1:]

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -62,6 +62,30 @@ class InlineTestCase(CottonInlineTestCase):
                 in response.content.decode()
             )
 
+    def test_attributes_that_end_or_start_with_quotes_are_preserved(self):
+        self.create_template(
+            "cotton/preserve_quotes.html",
+            """
+        <div {{ attrs }}><div>
+        """,
+        )
+
+        self.create_template(
+            "preserve_quotes_view.html",
+            """
+            <c-preserve-quotes something="var ? 'this' : 'that'" />
+            """,
+        )
+
+        # Register Url
+        self.register_url("view/", self.make_view("preserve_quotes_view.html"))
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.get_url_conf()):
+            response = self.client.get("/view/")
+
+            self.assertContains(response, '''"var ? 'this' : 'that'"''')
+
     def test_attribute_names_on_component_containing_hyphens_are_converted_to_underscores(
         self,
     ):


### PR DESCRIPTION
Fixes an issue where attributes containing alternate style trailing quotes would have their leading or trailing quote removed.

```html
<div x-on:click="something = 'that'"></div>
```

