### PR TITLE
better whitespace control

### DIFF
--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -360,3 +360,13 @@ class CottonTestCase(TestCase):
             response,
             """My template was not specified in settings!""",
         )
+
+    def test_expression_tags_close_to_tag_elements_doesnt_corrupt_the_tag(self):
+        html = """
+            <div{% if 1 = 1 %} attr1="variable" {% endif %}></div>
+        """
+
+        rendered = get_compiled(html)
+
+        self.assertFalse("</div{% if 1 = 1 %}>" in rendered, "Tag corrupted")
+        self.assertTrue("</div>" in rendered, "</div> not found in rendered string")

--- a/django_cotton/urls.py
+++ b/django_cotton/urls.py
@@ -1,5 +1,6 @@
 from . import views
 from django.urls import path
+from django.contrib import admin
 from django.views.generic import TemplateView
 
 app_name = "django_cotton"
@@ -19,6 +20,7 @@ class NamedSlotInLoop(TemplateView):
 
 
 urlpatterns = [
+    path("admin/", admin.site.urls),
     path("", TemplateView.as_view(template_name="index.html")),
     path("parent", TemplateView.as_view(template_name="parent_test.html")),
     path("child", TemplateView.as_view(template_name="child_test.html")),

--- a/django_cotton/urls.py
+++ b/django_cotton/urls.py
@@ -1,6 +1,6 @@
-from django.views.generic import TemplateView
 from . import views
 from django.urls import path
+from django.views.generic import TemplateView
 
 app_name = "django_cotton"
 

--- a/docs/docs_project/docs_project/templates/home.html
+++ b/docs/docs_project/docs_project/templates/home.html
@@ -10,6 +10,7 @@
                 <c-tag class="text-xl sm:text-2xl md:text-4xl">
                     {% verbatim %}{% block %}{% endverbatim %}
                 </c-tag>
+
                 <c-tag class="text-xl sm:text-2xl md:text-4xl">
                     {% verbatim %}{% include %}{% endverbatim %}
                 </c-tag>


### PR DESCRIPTION
Tags are being mutated if we have template expression against the opening tag name:

 i.e.
1. pre: `<div{% expr %}></div>`
2. mid process: `<div__placeholder></div__placeholder>`
3. post: `<div{% expr %}></div{% expr %}>`

This PR introduces better control to track and restore white space patten before and after processing. 