### PR TITLE
Preserve spaces around tpl expressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
 
       - name: Start Container
         run: |
-          docker-compose -f dev/docker/docker-compose.yaml up -d
+          docker compose -f dev/docker/docker-compose.yaml up -d
 
       - name: Run Tests
         run: docker exec -t cotton-dev-app python manage.py test
 
       - name: Stop and Remove Services
-        run: docker-compose -f dev/docker/docker-compose.yaml down
+        run: docker compose -f dev/docker/docker-compose.yaml down

--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -112,9 +112,9 @@ class CottonCompiler:
     def process(self, content, component_key):
         content = self._replace_syntax_with_placeholders(content)
         content = self._compile_cotton_to_django(content, component_key)
+        content = self._fix_bs4_attribute_empty_attribute_behaviour(content)
         content = self._replace_placeholders_with_syntax(content)
         content = self._remove_duplicate_attribute_markers(content)
-        content = self._revert_bs4_attribute_empty_attribute_fixing(content)
 
         return content
 
@@ -189,8 +189,8 @@ class CottonCompiler:
                 changes in the output that can lead to unintended tag type mutations,
                 i.e. <div{% expr %}></div> --> <div__placeholder></div__placeholder> --> <div{% expr %}></div{% expr %}>
                 """
-                left_group = r"(\s?)" if not placeholder["left_space"] else ""
-                right_group = r"(\s?)" if not placeholder["right_space"] else ""
+                left_group = r"(\s*)" if not placeholder["left_space"] else ""
+                right_group = r"(\s*)" if not placeholder["right_space"] else ""
                 placeholder_pattern = (
                     f"{left_group}{self.DJANGO_SYNTAX_PLACEHOLDER_PREFIX}{i}__{right_group}"
                 )
@@ -202,11 +202,10 @@ class CottonCompiler:
     def _remove_duplicate_attribute_markers(self, content):
         return re.sub(r"__COTTON_DUPE_ATTR__[0-9A-F]{5}", "", content)
 
-    def _revert_bs4_attribute_empty_attribute_fixing(self, contents):
-        """Bs4 adds ="" to empty attribute-like parts in HTML-like nodes.
-        This method removes these additions for Django template tags."""
-        contents = contents.replace('}}=""', "}}")
-        contents = contents.replace('%}=""', "%}")
+    def _fix_bs4_attribute_empty_attribute_behaviour(self, contents):
+        """Bs4 adds ="" to valueless attribute-like parts in HTML tags that causes issues when we want to manipulate
+        django expressions."""
+        contents = contents.replace('=""', "")
 
         return contents
 

--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -19,6 +19,10 @@ from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
 
 warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
 
+# If an update changes the API that a cached version of a template will break, we increment the cache version in order to
+# force the re-rendering of the template
+cache_version = "1"
+
 
 class Loader(BaseLoader):
     is_usable = True
@@ -360,7 +364,7 @@ class CottonTemplateCacheHandler:
 
     def get_cache_key(self, template_name, mtime):
         template_hash = hashlib.sha256(template_name.encode()).hexdigest()
-        return f"cotton_cache_{template_hash}_{mtime}"
+        return f"cotton_cache_v{cache_version}_{template_hash}_{mtime}"
 
     def get_cached_template(self, cache_key):
         if not self.enabled:

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -36,7 +36,13 @@ def cotton_component(parser, token):
 
     kwargs = {}
     for bit in bits[3:]:
-        key, value = bit.split("=")
+        try:
+            key, value = bit.split("=")
+        except ValueError:
+            # No value provided, assume boolean attribute
+            key = bit
+            value = ""
+
         kwargs[key] = value
 
     nodelist = parser.parse(("end_cotton_component",))
@@ -66,15 +72,11 @@ class CottonComponentNode(Node):
 
         # We need to check if any dynamic attributes are present in the component slots and move them over to attrs
         if "ctn_template_expression_attrs" in local_named_slots_ctx:
-            for expression_attr in local_named_slots_ctx[
-                "ctn_template_expression_attrs"
-            ]:
+            for expression_attr in local_named_slots_ctx["ctn_template_expression_attrs"]:
                 attrs[expression_attr] = local_named_slots_ctx[expression_attr]
 
         # Build attrs string before formatting any '-' to '_' in attr names
-        attrs_string = " ".join(
-            f"{key}={ensure_quoted(value)}" for key, value in attrs.items()
-        )
+        attrs_string = " ".join(f"{key}={ensure_quoted(value)}" for key, value in attrs.items())
         local_ctx["attrs"] = mark_safe(attrs_string)
         local_ctx["attrs_dict"] = attrs
 

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -212,6 +212,23 @@ class InlineTestCase(CottonInlineTestCase):
 
             self.assertContains(response, '@click="this=test"')
 
+    def test_spaces_are_maintained_around_expression_inside_attributes(self):
+        self.create_template(
+            "maintain_spaces_in_attributes_view.html",
+            """
+            <div some_attribute_{{ id }}_something="true"></div>
+            """,
+        )
+
+        # Register Url
+        self.register_url("view/", self.make_view("maintain_spaces_in_attributes_view.html"))
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.get_url_conf()):
+            response = self.client.get("/view/")
+
+            self.assertContains(response, "some_attribute__something")
+
 
 class CottonTestCase(TestCase):
     def test_parent_component_is_rendered(self):

--- a/django_cotton/tests/utils.py
+++ b/django_cotton/tests/utils.py
@@ -4,9 +4,7 @@ from django_cotton.cotton_loader import Loader as CottonLoader
 
 
 def get_compiled(template_string):
-    return CottonLoader(engine=None).cotton_compiler.process(
-        template_string, "test_key"
-    )
+    return CottonLoader(engine=None).cotton_compiler.process(template_string, "test_key")
 
 
 def get_rendered(template_string, context: dict = None):


### PR DESCRIPTION
It was identified that when using a template expression inside an html attribute name, whitespace was being inserted before and after, i.e.

`<div some_attribute_{{ id }}_key="...">`

output:

`<div some_attribute_ 1 _key="...">`

This PR fixes the issue. We also can now break the internal cache used for storing compiled components. This is needed to handle cases where api changes are made meaning cached versions of compiled templates will break.
