### PR TITLE
Check for cotton before processing

### DIFF
--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -21,7 +21,7 @@ warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
 
 # If an update changes the API that a cached version of a template will break, we increment the cache version in order to
 # force the re-rendering of the template
-cache_version = "1"
+cache_version = "2"
 
 
 class Loader(BaseLoader):
@@ -49,13 +49,10 @@ class Loader(BaseLoader):
         template_string = self._get_template_string(origin.name)
 
         # Do we need to process the template?
-        # if "<c-" not in template_string and "{% cotton_verbatim" not in template_string:
-        #     raise TemplateDoesNotExist(origin)
+        if "<c-" not in template_string and "{% cotton_verbatim" not in template_string:
+            raise TemplateDoesNotExist(origin)
 
         compiled_template = self.cotton_compiler.process(template_string, origin.template_name)
-
-        if "panel_button" in origin.template_name:
-            print(compiled_template)
 
         self.cache_handler.cache_template(cache_key, compiled_template)
 
@@ -173,7 +170,7 @@ class CottonCompiler:
 
         return content
 
-    def _compile_cotton_to_django(self, html_content, component_key):
+    def _compile_cotton_to_django(self, html_content, template_name):
         """Convert cotton <c-* syntax to {%."""
         soup = BeautifulSoup(
             html_content,
@@ -185,7 +182,7 @@ class CottonCompiler:
         if cvars_el := soup.find("c-vars"):
             soup = self._wrap_with_cotton_vars_frame(soup, cvars_el)
 
-        self._transform_components(soup, component_key)
+        self._transform_components(soup, template_name)
 
         return str(soup.encode(formatter=UnsortedAttributes()).decode("utf-8"))
 

--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -47,7 +47,15 @@ class Loader(BaseLoader):
             return cached_content
 
         template_string = self._get_template_string(origin.name)
+
+        # Do we need to process the template?
+        # if "<c-" not in template_string and "{% cotton_verbatim" not in template_string:
+        #     raise TemplateDoesNotExist(origin)
+
         compiled_template = self.cotton_compiler.process(template_string, origin.template_name)
+
+        if "panel_button" in origin.template_name:
+            print(compiled_template)
 
         self.cache_handler.cache_template(cache_key, compiled_template)
 
@@ -113,9 +121,9 @@ class CottonCompiler:
     def __init__(self):
         self.django_syntax_placeholders = []
 
-    def process(self, content, component_key):
+    def process(self, content, template_name):
         content = self._replace_syntax_with_placeholders(content)
-        content = self._compile_cotton_to_django(content, component_key)
+        content = self._compile_cotton_to_django(content, template_name)
         content = self._fix_bs4_attribute_empty_attribute_behaviour(content)
         content = self._replace_placeholders_with_syntax(content)
         content = self._remove_duplicate_attribute_markers(content)

--- a/docs/docs_project/docs_project/settings.py
+++ b/docs/docs_project/docs_project/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django_cotton",
     "heroicons",
+    "debug_toolbar",
 ]
 
 MIDDLEWARE = [
@@ -54,6 +55,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "docs_project.urls"
@@ -129,6 +131,13 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
+INTERNAL_IPS = [
+    # ...
+    "127.0.0.1",
+    "0.0.0.0"
+    # ...
+]
+
 LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "UTC"
@@ -159,6 +168,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+COTTON_TEMPLATE_CACHING_ENABLED = False
 
 CACHES = {
     "default": {

--- a/docs/docs_project/docs_project/settings.py
+++ b/docs/docs_project/docs_project/settings.py
@@ -42,7 +42,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django_cotton",
     "heroicons",
-    "debug_toolbar",
 ]
 
 MIDDLEWARE = [
@@ -55,7 +54,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "docs_project.urls"
@@ -131,13 +129,6 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-INTERNAL_IPS = [
-    # ...
-    "127.0.0.1",
-    "0.0.0.0"
-    # ...
-]
-
 LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "UTC"
@@ -168,7 +159,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-COTTON_TEMPLATE_CACHING_ENABLED = False
+COTTON_TEMPLATE_CACHING_ENABLED = True
 
 CACHES = {
     "default": {

--- a/docs/docs_project/docs_project/templates/cotton/navbar.html
+++ b/docs/docs_project/docs_project/templates/cotton/navbar.html
@@ -1,6 +1,6 @@
 <div class="py-5 sticky top-0 md:top-auto bg-amber-50 dark:bg-gray-900 border-opacity-15 z-10" :class="{'bg-white dark:bg-gray-800': isOpen}"
      x-data="{isOpen: false}"
-     x-init="h
+     x-init="
         window.addEventListener('resize', () => {
             if (window.matchMedia('(min-width: 640px)').matches) {
                 isOpen = false;

--- a/docs/docs_project/docs_project/urls.py
+++ b/docs/docs_project/docs_project/urls.py
@@ -1,3 +1,5 @@
+from debug_toolbar.toolbar import debug_toolbar_urls
+
 from . import views
 from django.urls import path
 
@@ -21,4 +23,4 @@ urlpatterns = [
     path("docs/icons", views.build_view("icons"), name="icons"),
     # More
     path("docs/configuration", views.build_view("configuration"), name="configuration"),
-]
+] + debug_toolbar_urls()

--- a/docs/docs_project/docs_project/urls.py
+++ b/docs/docs_project/docs_project/urls.py
@@ -1,5 +1,3 @@
-from debug_toolbar.toolbar import debug_toolbar_urls
-
 from . import views
 from django.urls import path
 
@@ -23,4 +21,4 @@ urlpatterns = [
     path("docs/icons", views.build_view("icons"), name="icons"),
     # More
     path("docs/configuration", views.build_view("configuration"), name="configuration"),
-] + debug_toolbar_urls()
+]


### PR DESCRIPTION
An [issue](#75) led to the discovery of a problem when processing debug_toolbar templates. This PR introduces a check to see whether a template includes any cotton tag before processing it, instead of the current behaviour which compiles all templates.

This is more of a patch rather than a fix of the real underlying issue I detected, which requires more time to address.