### PR TITLE
auto setup, refactored caching, removed lru

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ In addition, Cotton enables you to navigate around some of the limitations with 
 
 ## Caching
 
-Cotton components are cached whilst in production (`DEBUG = False`). The cache's TTL is for the duration of your app's lifetime. So on deployment, when the app is normally restarted, caches are cleared. During development, changes are detected on every component render. This feature is a work in progress and some refinement is planned.
+Cotton is optimal when used with Django's cached.Loader. If you use auto-setup then the cached loader will be automatically applied. This feature is a work in progress and some refinement is planned.
 
 For full docs and demos, checkout <a href="https://django-cotton.com" target="_blank">django-cotton.com</a>
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,10 @@ In addition, Cotton enables you to navigate around some of the limitations with 
 
 ## Caching
 
-Cotton is optimal when used with Django's cached.Loader. If you use auto-setup then the cached loader will be automatically applied. This feature is a work in progress and some refinement is planned.
+Cotton is optimal when used with Django's cached.Loader. If you use <a href="https://django-cotton.com/docs/quickstart">automatic configuration</a> then the cached loader will be automatically applied. This feature has room for improvement, some desirables are:
+
+- Integration with a cache backend to survive runtime restarts / deployments.
+- Cache warming
 
 For full docs and demos, checkout <a href="https://django-cotton.com" target="_blank">django-cotton.com</a>
 

--- a/dev/example_project/render_load_test.py
+++ b/dev/example_project/render_load_test.py
@@ -27,26 +27,20 @@ settings.configure(
                     "django.contrib.auth.context_processors.auth",
                     "django.contrib.messages.context_processors.messages",
                 ],
-                "loaders": [
-                    "django_cotton.cotton_loader.Loader",
-                    "django.template.loaders.filesystem.Loader",
-                    "django.template.loaders.app_directories.Loader",
-                ],
                 "builtins": [
                     "django.templatetags.static",
-                    "django_cotton.templatetags.cotton",
                 ],
             },
         },
     ],
-    COTTON_TEMPLATE_CACHING_ENABLED=True,
+    COTTON_TEMPLATE_CACHING_ENABLED=False,
     DEBUG=False,
 )
 
 django.setup()
 
 
-def template_bench(template_name, iterations=10000):
+def template_bench(template_name, iterations=500):
     start_time = time.time()
     for _ in range(iterations):
         render_to_string(template_name)
@@ -54,7 +48,7 @@ def template_bench(template_name, iterations=10000):
     return end_time - start_time, render_to_string(template_name)
 
 
-def template_bench_alt(template_name, iterations=10000):
+def template_bench_alt(template_name, iterations=500):
     data = list(range(1, iterations))
     start_time = time.time()
     render_to_string(template_name, context={"data": data})

--- a/django_cotton/apps.py
+++ b/django_cotton/apps.py
@@ -1,0 +1,76 @@
+"""
+django-cotton
+
+App configuration to set up the cotton loader and builtins automatically.
+"""
+
+from contextlib import suppress
+
+import django.contrib.admin
+import django.template
+from django.apps import AppConfig
+from django.conf import settings
+
+
+def wrap_loaders(name):
+    for template_config in settings.TEMPLATES:
+        engine_name = template_config.get("NAME")
+        if not engine_name:
+            engine_name = template_config["BACKEND"].split(".")[-2]
+        if engine_name == name:
+            loaders = template_config.setdefault("OPTIONS", {}).get("loaders", [])
+
+            loaders_already_configured = (
+                loaders
+                and isinstance(loaders, (list, tuple))
+                and isinstance(loaders[0], (tuple, list))
+                and loaders[0][0] == "django.template.loaders.cached.Loader"
+                and "django_cotton.cotton_loader.Loader" in loaders[0][1]
+            )
+
+            if not loaders_already_configured:
+                template_config.pop("APP_DIRS", None)
+                default_loaders = [
+                    "django_cotton.cotton_loader.Loader",
+                    "django.template.loaders.filesystem.Loader",
+                    "django.template.loaders.app_directories.Loader",
+                ]
+                cached_loaders = [("django.template.loaders.cached.Loader", default_loaders)]
+                template_config["OPTIONS"]["loaders"] = cached_loaders
+
+            builtins = template_config.setdefault("OPTIONS", {}).get("builtins", [])
+            builtins_already_configured = (
+                builtins and "django_cotton.templatetags.cotton" in builtins
+            )
+            if not builtins_already_configured:
+                template_config["OPTIONS"]["builtins"].insert(
+                    0, "django_cotton.templatetags.cotton"
+                )
+
+            break
+
+    # Force re-evaluation of settings.TEMPLATES because EngineHandler caches it.
+    with suppress(AttributeError):
+        del django.template.engines.templates
+        django.template.engines._engines = {}
+
+
+class LoaderAppConfig(AppConfig):
+    """
+    This, the default configuration, does the automatic setup of a partials loader.
+    """
+
+    name = "django_cotton"
+    default = True
+
+    def ready(self):
+        wrap_loaders("django")
+
+
+class SimpleAppConfig(AppConfig):
+    """
+    This, the non-default configuration, allows the user to opt-out of the automatic configuration. They just need to
+    add "django_cotton.apps.SimpleAppConfig" to INSTALLED_APPS instead of "django_cotton".
+    """
+
+    name = "django_cotton"

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -1,26 +1,11 @@
 import ast
-from functools import lru_cache
 
 from django import template
-from django.conf import settings
 from django.template import Node
-from django.template.loader import get_template
 from django.utils.safestring import mark_safe
+from django.template.loader import get_template
 
 from django_cotton.utils import ensure_quoted
-
-
-@lru_cache(maxsize=1024)
-def get_cached_template(template_name):
-    """App runtime cache for cotton templates. Turned on only when DEBUG=False."""
-    return get_template(template_name)
-
-
-def render_template(template_name, context):
-    if settings.DEBUG:
-        return get_template(template_name).render(context)
-    else:
-        return get_cached_template(template_name).render(context)
 
 
 def cotton_component(parser, token):
@@ -87,7 +72,7 @@ class CottonComponentNode(Node):
         # Reset the component's slots in context to prevent data leaking between components
         all_named_slots_ctx[self.component_key] = {}
 
-        return render_template(self.template_path, local_ctx)
+        return get_template(self.template_path).render(local_ctx)
 
     def _build_attrs(self, context):
         """

--- a/docs/docs_project/docs_project/settings.py
+++ b/docs/docs_project/docs_project/settings.py
@@ -40,7 +40,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "django_cotton",
+    "django_cotton.apps.SimpleAppConfig",
+    # "django_cotton",
     "heroicons",
 ]
 
@@ -80,14 +81,14 @@ TEMPLATES = [
                         "django.template.loaders.filesystem.Loader",
                         "django.template.loaders.app_directories.Loader",
                     ],
-                )
+                ),
             ],
             "builtins": [
                 "django.templatetags.static",
-                "django_cotton.templatetags.cotton",
                 "docs_project.templatetags.force_escape",
                 "docs_project.templatetags.custom_tags",
                 "heroicons.templatetags.heroicons",
+                "django_cotton.templatetags.cotton",
             ],
         },
     },

--- a/docs/docs_project/docs_project/settings.py
+++ b/docs/docs_project/docs_project/settings.py
@@ -40,8 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "django_cotton.apps.SimpleAppConfig",
-    # "django_cotton",
+    "django_cotton",
     "heroicons",
 ]
 
@@ -65,7 +64,7 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": ["docs_project/templates"],
-        "APP_DIRS": False,
+        "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.debug",
@@ -73,22 +72,11 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
             ],
-            "loaders": [
-                (
-                    "django.template.loaders.cached.Loader",
-                    [
-                        "django_cotton.cotton_loader.Loader",
-                        "django.template.loaders.filesystem.Loader",
-                        "django.template.loaders.app_directories.Loader",
-                    ],
-                ),
-            ],
             "builtins": [
                 "django.templatetags.static",
                 "docs_project.templatetags.force_escape",
                 "docs_project.templatetags.custom_tags",
                 "heroicons.templatetags.heroicons",
-                "django_cotton.templatetags.cotton",
             ],
         },
     },

--- a/docs/docs_project/docs_project/templates/quickstart.html
+++ b/docs/docs_project/docs_project/templates/quickstart.html
@@ -15,31 +15,46 @@
     <h2>Install cotton</h2>
     <p>Run the following command:</p>
     <c-snippet language="python">pip install django-cotton</c-snippet>
+
     <p>Then update your settings.py:</p>
+
+    <h3>Automatic configuration:</h3>
 
     <c-snippet language="python" label="settings.py">{% cotton_verbatim %}{% verbatim %}
 INSTALLED_APPS = [
-    ...
     'django_cotton',
+]
+    {% endverbatim %}{% endcotton_verbatim %}</c-snippet>
+
+    <p>This will automatically handle the settings.py adding the required loader and templatetags.</p>
+
+    <h3>Customised configuration</h3>
+
+    <p>If your project requires any non-default loaders or you do not wish Cotton to manage your settings, you should instead provide `django_cotton.apps.SimpleAppConfig` in your INSTALLED_APPS:</p>
+
+    <c-snippet language="python" label="settings.py">{% cotton_verbatim %}{% verbatim %}
+INSTALLED_APPS = [
+    'django_cotton.apps.SimpleAppConfig',
 ]
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': ['your_project/templates'], # Add your template directories here
-        'APP_DIRS': False,
-        'OPTIONS': {
-            'loaders': [
-                'django_cotton.cotton_loader.Loader', # First position
-                # continue with default loaders, typically:
-                # "django.template.loaders.filesystem.Loader",
-                # "django.template.loaders.app_directories.Loader",
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        ...
+        "OPTIONS": {
+            "loaders": [(
+                "django.template.loaders.cached.Loader",
+                [
+                    "django_cotton.cotton_loader.Loader",
+                    "django.template.loaders.filesystem.Loader",
+                    "django.template.loaders.app_directories.Loader",
+                ],
+            )],
+            "builtins": [
+                "django_cotton.templatetags.cotton"
             ],
-            'builtins': [
-                'django_cotton.templatetags.cotton',
-            ],
-        },
-    },
+        }
+    }
 ]
     {% endverbatim %}{% endcotton_verbatim %}</c-snippet>
 


### PR DESCRIPTION
To address some of the recent issues around caching + performance in development, this PR:

- Removes LRU cache caching in favour of using Django's cached loader 
- Simplifies in-loader caching as a suitable fallback for instances when using Django's cached loader is not desirable
- Introduces an auto-configuration to manage settings.py (loaders and builtins) inspired by Carlton Gibson's django template partials. You will now be able to remove `loaders` and the cotton template tags from `builtins` by just providing `django_cotton` in `INSTALLED_APPS`. If you still need a bespoke `TEMPLATES` setup then you can define `django_cotton.apps.SimpleAppConfig` instead.