### PR TITLE
Fixed auto-setup where no `builtins` key present

### DIFF
--- a/dev/example_project/example_project/settings.py
+++ b/dev/example_project/example_project/settings.py
@@ -66,20 +66,6 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
             ],
-            "loaders": [
-                (
-                    "django.template.loaders.cached.Loader",
-                    [
-                        "django_cotton.cotton_loader.Loader",
-                        "django.template.loaders.filesystem.Loader",
-                        "django.template.loaders.app_directories.Loader",
-                    ],
-                )
-            ],
-            "builtins": [
-                "django.templatetags.static",
-                "django_cotton.templatetags.cotton",
-            ],
         },
     },
 ]

--- a/django_cotton/apps.py
+++ b/django_cotton/apps.py
@@ -38,7 +38,8 @@ def wrap_loaders(name):
                 cached_loaders = [("django.template.loaders.cached.Loader", default_loaders)]
                 template_config["OPTIONS"]["loaders"] = cached_loaders
 
-            builtins = template_config.setdefault("OPTIONS", {}).get("builtins", [])
+            options = template_config.setdefault("OPTIONS", {})
+            builtins = options.setdefault("builtins", [])
             builtins_already_configured = (
                 builtins and "django_cotton.templatetags.cotton" in builtins
             )


### PR DESCRIPTION
As reported [here](#91), we should ensure `builtins` key exists from within AppConfig 