### PR TITLE
Parse template inside dynamic attributes

### DIFF
--- a/django_cotton/templatetags/_slot.py
+++ b/django_cotton/templatetags/_slot.py
@@ -38,19 +38,15 @@ class CottonSlotNode(template.Node):
         if self.component_key not in context["cotton_named_slots"]:
             context["cotton_named_slots"][self.component_key] = {}
 
-        context["cotton_named_slots"][self.component_key][self.slot_name] = mark_safe(
-            output
-        )
+        context["cotton_named_slots"][self.component_key][self.slot_name] = mark_safe(output)
 
-        # If the slot is being used as an expression attribute, we record it so it can be transferred to attrs in the component
+        # If the slot is being used to hold an expression attribute, we record it so it can be transferred to attrs in the component
         if self.is_expression_attr:
             key = "ctn_template_expression_attrs"
 
             if key not in context["cotton_named_slots"][self.component_key]:
                 context["cotton_named_slots"][self.component_key][key] = []
 
-            context["cotton_named_slots"][self.component_key][key].append(
-                self.slot_name
-            )
+            context["cotton_named_slots"][self.component_key][key].append(self.slot_name)
 
         return ""

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -260,7 +260,7 @@ class InlineTestCase(CottonInlineTestCase):
 
         self.assertTrue("I am dynamic component from expression" in rendered)
 
-    def test_spaces_are_maintained_around_expression_inside_attributes(self):
+    def test_spaces_are_maintained_around_expressions_inside_attributes(self):
         self.create_template(
             "maintain_spaces_in_attributes_view.html",
             """
@@ -268,6 +268,23 @@ class InlineTestCase(CottonInlineTestCase):
             """,
             "view/",
         )
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.get_url_conf()):
+            response = self.client.get("/view/")
+
+            self.assertContains(response, "some_attribute__something")
+
+    def test_dynamic_attributes_are_parsed(self):
+        self.create_template(
+            "dynamic_attributes_parse_view.html",
+            """
+            <c-dynamic-attribute-template-parsing :test="[{{ img }}]" />
+            """,
+            "view/",
+        )
+        
+        self.
 
         # Override URLconf
         with self.settings(ROOT_URLCONF=self.get_url_conf()):

--- a/django_cotton/tests/test_cotton.py
+++ b/django_cotton/tests/test_cotton.py
@@ -275,22 +275,30 @@ class InlineTestCase(CottonInlineTestCase):
 
             self.assertContains(response, "some_attribute__something")
 
-    def test_dynamic_attributes_are_parsed(self):
+    def test_dynamic_attributes_are_also_template_parsed(self):
         self.create_template(
-            "dynamic_attributes_parse_view.html",
+            "cotton/dynamic_attribute_template_parsing.html",
             """
-            <c-dynamic-attribute-template-parsing :test="[{{ img }}]" />
+            {% for image in images %}
+                {{ forloop.counter }}: {{ image }}
+            {% endfor %}
+            """,
+        )
+
+        self.create_template(
+            "dynamic_attributes_parsing_view.html",
+            """
+            <c-dynamic-attribute-template-parsing :images="['{{ image1 }}', '{{ image2 }}']" />
             """,
             "view/",
+            context={"image1": "1.jpg", "image2": "2.jpg"},
         )
-        
-        self.
 
         # Override URLconf
         with self.settings(ROOT_URLCONF=self.get_url_conf()):
             response = self.client.get("/view/")
-
-            self.assertContains(response, "some_attribute__something")
+            self.assertContains(response, "1: 1.jpg")
+            self.assertContains(response, "2: 2.jpg")
 
 
 class CottonTestCase(TestCase):

--- a/docs/docs_project/docs_project/templates/cotton/feature_tile.html
+++ b/docs/docs_project/docs_project/templates/cotton/feature_tile.html
@@ -1,6 +1,10 @@
 <div class="flex space-x-2 rounded-lg px-8 py-5 dark:border border-gray-700 bg-white shadow-md dark:bg-transparent">
     {{ icon }}
 
+    {% if disabled is True %}
+     TRUE
+    {% endif %}
+
     <div>
         <div class="text-xl mb-3 font-semibold dark:text-white">{{ title }}</div>
         <div class="text-[15px]">{{ slot }}</div>

--- a/docs/docs_project/docs_project/templates/home.html
+++ b/docs/docs_project/docs_project/templates/home.html
@@ -134,7 +134,7 @@ Item Title
             <h3 class="text-center pb-10">Why cotton?</h3>
 
             <c-feature-tiles>
-                <c-feature-tile title="Rapid UI composition">
+                <c-feature-tile :disabled="1" title="Rapid UI composition">
                     <c-slot name="icon">
                         {% heroicon_outline 'fire' class="shrink-0 text-teal-600 size-16 mr-5 mt-1" stroke_width="1.8" %}
                     </c-slot>


### PR DESCRIPTION
With this PR, we can now perform things like this:

```html
<c-slider :images="['{{ image1 }}', '{{ image2 }}']" />
<!-- provides list of images in the component -->

<c-map :location="{
  'longitude': {{ longitude }},
  'latitude': {{ latitude }}
}" />
<!-- provides dict in the component -->

<c-graph :data="{ 'series': {% get_graph_data %} }" />
<!-- provides dict in the component -->
```