### PR TITLE
Support quoted json-like values in {{ attrs }}

### DIFF
--- a/django_cotton/tests/test_attributes.py
+++ b/django_cotton/tests/test_attributes.py
@@ -502,3 +502,51 @@ class AttributeHandlingTests(CottonTestCase):
         with self.settings(ROOT_URLCONF=self.url_conf()):
             response = self.client.get("/view/")
             self.assertTrue(response.status_code == 200)
+
+    def test_htmx_attribute_values_single_quote(self):
+        # tests for json-like values
+        self.create_template(
+            "cotton/htmx.html",
+            """
+            <div {{ attrs }}><div>
+            """,
+        )
+
+        self.create_template(
+            "htmx_view.html",
+            """
+            <c-htmx
+              hx-vals='{"id": "1"}'
+            />
+            """,
+            "view/",
+        )
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, """'{"id": "1"}'""")
+
+    def test_htmx_attribute_values_double_quote(self):
+        # tests for json-like values
+        self.create_template(
+            "cotton/htmx2.html",
+            """
+            <div {{ attrs }}><div>
+            """,
+        )
+
+        self.create_template(
+            "htmx_view2.html",
+            """
+            <c-htmx2
+              hx-vals="{'id': '1'}"
+            />
+            """,
+            "view/",
+        )
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "\"{'id': '1'}\"")

--- a/django_cotton/utils.py
+++ b/django_cotton/utils.py
@@ -12,7 +12,9 @@ def eval_string(value):
 
 
 def ensure_quoted(value):
-    if isinstance(value, str) and value.startswith('"') and value.endswith('"'):
-        return value
-    else:
-        return f'"{value}"'
+    if isinstance(value, str):
+        if value.startswith('{"') and value.endswith('}'):
+            return f"'{value}'"  # use single quotes for json-like strings
+        elif value.startswith('"') and value.endswith('"'):
+            return value  # already quoted
+    return f'"{value}"'  # default to double quotes


### PR DESCRIPTION
I have an app that uses `django-cotton` that has a template referencing a cotton component as follows:

`<c-event.delete-button hx-vals='{"tid": "{{ event.tid }}"}' @click.prevent="" />`


delete-button.html
```
<button
    {{ attrs }}
    class="..."
    hx-post="{% url 'delete_event' %}"
    hx-confirm="Are you sure you want to delete this event?">
    🗑️
</button>
```

Single quote json-like values are not supported currently by django-cotton in {{ attrs }}. this PR adds 2 tests and support for the above.