### PR TITLE
Test empty cvars

### DIFF
--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -226,6 +226,9 @@ class CottonCompiler:
         govern vars and attributes. To be able to defined new vars within a component and also have them available in the
         same component's context, we wrap the entire contents in another component: cotton_vars_frame. Only when <c-vars>
         is present."""
+
+        print(cvars_el.attrs.items())
+
         cvars_attrs_string = " ".join(f'{k}="{v}"' for k, v in cvars_el.attrs.items())
         cvars_el.decompose()
         opening = f"{{% vars {cvars_attrs_string} %}}"

--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -227,9 +227,10 @@ class CottonCompiler:
         same component's context, we wrap the entire contents in another component: cotton_vars_frame. Only when <c-vars>
         is present."""
 
-        print(cvars_el.attrs.items())
+        cvars_attrs_string = " ".join(
+            f'{k}="{" ".join(v) if k == "class" else v}"' for k, v in cvars_el.attrs.items()
+        )
 
-        cvars_attrs_string = " ".join(f'{k}="{v}"' for k, v in cvars_el.attrs.items())
         cvars_el.decompose()
         opening = f"{{% vars {cvars_attrs_string} %}}"
         opening = opening.replace("\n", "")

--- a/django_cotton/templatetags/_vars.py
+++ b/django_cotton/templatetags/_vars.py
@@ -36,7 +36,7 @@ class CottonVarsNode(Node):
                     else:
                         try:
                             resolved_value = Variable(value).resolve(context)
-                        except VariableDoesNotExist:
+                        except (VariableDoesNotExist, IndexError):
                             resolved_value = value
                         attrs[key] = resolved_value
 

--- a/django_cotton/tests/test_attributes.py
+++ b/django_cotton/tests/test_attributes.py
@@ -79,75 +79,6 @@ class AttributeHandlingTests(CottonTestCase):
             self.assertContains(response, "variable is 111")
             self.assertContains(response, "template_string_lit.dummy is 222")
 
-    def test_dynamic_attributes_in_cvars(self):
-        self.create_template(
-            "eval_attributes_in_cvars_view.html",
-            """
-                <c-dynamic-attributes-cvars />        
-            """,
-            "view/",
-        )
-
-        self.create_template(
-            "cotton/dynamic_attributes_cvars.html",
-            """
-                <c-vars 
-                    :none="None" 
-                    :number="1" 
-                    :boolean_true="True" 
-                    :boolean_false="False" 
-                    :dict="{'key': 'value'}" 
-                    :list="[1, 2, 3]" 
-                    :listdict="[{'key': 'value'}]" 
-                    :variable="111"             
-                />
-                
-                {% if none is None %}
-                    <p>none is None</p>
-                {% endif %}
-                
-                {% if number == 1 %}
-                    <p>number is 1</p>
-                {% endif %}
-                
-                {% if boolean_true is True %}
-                    <p>boolean_true is True</p>
-                {% endif %}
-                
-                {% if boolean_false is False %}
-                    <p>boolean_false is False</p>
-                {% endif %}
-                
-                {% if dict.key == 'value' %}
-                    <p>dict.key is 'value'</p>
-                {% endif %}
-                
-                {% if list.0 == 1 %}
-                    <p>list.0 is 1</p>
-                {% endif %}
-                
-                {% if listdict.0.key == 'value' %}
-                    <p>listdict.0.key is 'value'</p>
-                {% endif %}
-
-                {% if variable == 111 %}
-                    <p>variable is 111</p>
-                {% endif %}   
-            """,
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-
-            self.assertContains(response, "none is None")
-            self.assertContains(response, "number is 1")
-            self.assertContains(response, "boolean_true is True")
-            self.assertContains(response, "boolean_false is False")
-            self.assertContains(response, "list.0 is 1")
-            self.assertContains(response, "dict.key is 'value'")
-            self.assertContains(response, "listdict.0.key is 'value'")
-            self.assertContains(response, "variable is 111")
-
     def test_we_can_govern_whole_attributes_in_html_elements(self):
         self.create_template(
             "cotton/attribute_govern.html",
@@ -184,32 +115,6 @@ class AttributeHandlingTests(CottonTestCase):
             "hyphens_view.html",
             """
             <c-hyphens x-data="{}" x-init="do_something()" />
-            """,
-            "view/",
-        )
-
-        # Override URLconf
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-
-            self.assertContains(response, 'x-data="{}" x-init="do_something()"')
-
-    def test_attribute_names_on_cvars_containing_hyphens_are_converted_to_underscores(
-        self,
-    ):
-        self.create_template(
-            "cotton/cvar_hyphens.html",
-            """
-            <c-vars x-data="{}" x-init="do_something()" />
-            
-            <div x-data="{{ x_data }}" x-init="{{ x_init }}"></div>
-            """,
-        )
-
-        self.create_template(
-            "cvar_hyphens_view.html",
-            """
-            <c-cvar-hyphens />
             """,
             "view/",
         )
@@ -259,29 +164,6 @@ class AttributeHandlingTests(CottonTestCase):
 
             self.assertContains(response, "some_attribute__something")
 
-    def test_boolean_attributes(self):
-        self.create_template(
-            "cotton/boolean_attribute.html",
-            """
-                {% if is_something is True %}
-                    It's True
-                {% endif %}
-            """,
-        )
-
-        self.create_template(
-            "boolean_attribute_view.html",
-            """
-                <c-boolean-attribute is_something />
-            """,
-            "view/",
-        )
-
-        # Override URLconf
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertContains(response, "It's True")
-
     def test_attributes_without_colons_are_not_evaluated(self):
         self.create_template(
             "cotton/static_attrs.html",
@@ -309,29 +191,6 @@ class AttributeHandlingTests(CottonTestCase):
         with self.settings(ROOT_URLCONF=self.url_conf()):
             response = self.client.get("/view/")
             self.assertContains(response, "All good")
-
-    def test_unprocessable_dynamic_attributes_fallback_to_cvar_defaults(self):
-        self.create_template(
-            "cotton/unprocessable_dynamic_attribute.html",
-            """
-                <c-vars color="gray" />
-                
-                {{ color }}
-            """,
-        )
-
-        self.create_template(
-            "unprocessable_dynamic_attribute_view.html",
-            """
-                <c-unprocessable-dynamic-attribute :color="button.color" />
-            """,
-            "view/",
-            context={},
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertTrue("gray" in response.content.decode())
 
     def test_attribute_merging(self):
         self.create_template(
@@ -418,67 +277,6 @@ class AttributeHandlingTests(CottonTestCase):
             """,
         )
 
-    def test_empty_cvar_is_removed_from_attrs_string(self):
-        self.create_template(
-            "empty_cvar_view.html",
-            """
-                <c-empty-cvar var="im a cvar" attr="im a fallthrough" />
-            """,
-            "view/",
-        )
-
-        self.create_template(
-            "cotton/empty_cvar.html",
-            """
-                <c-vars var />
-                
-                attr: '{{ attr }}'
-                var: '{{ var }}'
-                attrs: '{{ attrs }}'
-            """,
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertContains(response, "attr: 'im a fallthrough'")
-            self.assertContains(response, "var: 'im a cvar'")
-            self.assertContains(response, """attrs: 'attr="im a fallthrough"'""")
-
-    def test_attrs_do_not_contain_cvars(self):
-        self.create_template(
-            "cvars_test_view.html",
-            """
-                <c-cvars-test-component var="im a var" attr="im an attr">
-                    default slot
-                </c-cvars-test-component>        
-            """,
-            "view/",
-        )
-
-        self.create_template(
-            "cotton/cvars_test_component.html",
-            """
-                <c-vars var="sds" prop_with_default="1" />
-                
-                <div>
-                    {{ testy }}
-                    <p>var: '{{ var }}'</p>
-                    <p>attr: '{{ attr }}'</p>
-                    <p>empty_var: '{{ empty_var }}'</p>
-                    <p>var_with_default: '{{ var_with_default }}'</p>
-                    <p>slot: '{{ slot }}'</p>
-                    <p>named_slot: '{{ named_slot }}'</p>
-                    <p>attrs: '{{ attrs }}'</p>
-                </div>
-            """,
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertContains(response, "attr: 'im an attr'")
-            self.assertContains(response, "var: 'im a var'")
-            self.assertContains(response, """attrs: 'attr="im an attr"'""")
-
     def test_attribute_passing(self):
         self.create_template(
             "attribute_passing_view.html",
@@ -502,25 +300,6 @@ class AttributeHandlingTests(CottonTestCase):
             compiled,
             """<a href="#" class="test" class="test2">hello</a>""",
         )
-
-    def test_multiline_cvar_values(self):
-        self.create_template(
-            "multiline_cvar_values_view.html",
-            """<c-multiline-cvar-values />""",
-            "view/",
-        )
-
-        self.create_template(
-            "cotton/multiline_cvar_values.html",
-            """
-                <c-vars multiline="line1
-                line2" />
-            """,
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertTrue(response.status_code == 200)
 
     def test_boolean_attributes(self):
         self.create_template(

--- a/django_cotton/tests/test_cvars.py
+++ b/django_cotton/tests/test_cvars.py
@@ -1,0 +1,246 @@
+from django_cotton.tests.utils import CottonTestCase
+
+
+class CvarTests(CottonTestCase):
+    def test_dynamic_attributes_in_cvars(self):
+        self.create_template(
+            "eval_attributes_in_cvars_view.html",
+            """
+                <c-dynamic-attributes-cvars />        
+            """,
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/dynamic_attributes_cvars.html",
+            """
+                <c-vars 
+                    :none="None" 
+                    :number="1" 
+                    :boolean_true="True" 
+                    :boolean_false="False" 
+                    :dict="{'key': 'value'}" 
+                    :list="[1, 2, 3]" 
+                    :listdict="[{'key': 'value'}]" 
+                    :variable="111"             
+                />
+                
+                {% if none is None %}
+                    <p>none is None</p>
+                {% endif %}
+                
+                {% if number == 1 %}
+                    <p>number is 1</p>
+                {% endif %}
+                
+                {% if boolean_true is True %}
+                    <p>boolean_true is True</p>
+                {% endif %}
+                
+                {% if boolean_false is False %}
+                    <p>boolean_false is False</p>
+                {% endif %}
+                
+                {% if dict.key == 'value' %}
+                    <p>dict.key is 'value'</p>
+                {% endif %}
+                
+                {% if list.0 == 1 %}
+                    <p>list.0 is 1</p>
+                {% endif %}
+                
+                {% if listdict.0.key == 'value' %}
+                    <p>listdict.0.key is 'value'</p>
+                {% endif %}
+
+                {% if variable == 111 %}
+                    <p>variable is 111</p>
+                {% endif %}   
+            """,
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+
+            self.assertContains(response, "none is None")
+            self.assertContains(response, "number is 1")
+            self.assertContains(response, "boolean_true is True")
+            self.assertContains(response, "boolean_false is False")
+            self.assertContains(response, "list.0 is 1")
+            self.assertContains(response, "dict.key is 'value'")
+            self.assertContains(response, "listdict.0.key is 'value'")
+            self.assertContains(response, "variable is 111")
+
+    def test_attribute_names_on_cvars_containing_hyphens_are_converted_to_underscores(
+        self,
+    ):
+        self.create_template(
+            "cotton/cvar_hyphens.html",
+            """
+            <c-vars x-data="{}" x-init="do_something()" />
+            
+            <div x-data="{{ x_data }}" x-init="{{ x_init }}"></div>
+            """,
+        )
+
+        self.create_template(
+            "cvar_hyphens_view.html",
+            """
+            <c-cvar-hyphens />
+            """,
+            "view/",
+        )
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+
+            self.assertContains(response, 'x-data="{}" x-init="do_something()"')
+
+    def test_unprocessable_dynamic_attributes_fallback_to_cvar_defaults(self):
+        self.create_template(
+            "cotton/unprocessable_dynamic_attribute.html",
+            """
+                <c-vars color="gray" />
+                
+                {{ color }}
+            """,
+        )
+
+        self.create_template(
+            "unprocessable_dynamic_attribute_view.html",
+            """
+                <c-unprocessable-dynamic-attribute :color="button.color" />
+            """,
+            "view/",
+            context={},
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertTrue("gray" in response.content.decode())
+
+    def test_empty_cvar_is_removed_from_attrs_string(self):
+        self.create_template(
+            "empty_cvar_view.html",
+            """
+                <c-empty-cvar var="im a cvar" attr="im a fallthrough" />
+            """,
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/empty_cvar.html",
+            """
+                <c-vars var />
+                
+                attr: '{{ attr }}'
+                var: '{{ var }}'
+                attrs: '{{ attrs }}'
+            """,
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "attr: 'im a fallthrough'")
+            self.assertContains(response, "var: 'im a cvar'")
+            self.assertContains(response, """attrs: 'attr="im a fallthrough"'""")
+
+    def test_attrs_do_not_contain_cvars(self):
+        self.create_template(
+            "cvars_test_view.html",
+            """
+                <c-cvars-test-component var="im a var" attr="im an attr">
+                    default slot
+                </c-cvars-test-component>        
+            """,
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/cvars_test_component.html",
+            """
+                <c-vars var="sds" prop_with_default="1" />
+                
+                <div>
+                    {{ testy }}
+                    <p>var: '{{ var }}'</p>
+                    <p>attr: '{{ attr }}'</p>
+                    <p>empty_var: '{{ empty_var }}'</p>
+                    <p>var_with_default: '{{ var_with_default }}'</p>
+                    <p>slot: '{{ slot }}'</p>
+                    <p>named_slot: '{{ named_slot }}'</p>
+                    <p>attrs: '{{ attrs }}'</p>
+                </div>
+            """,
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "attr: 'im an attr'")
+            self.assertContains(response, "var: 'im a var'")
+            self.assertContains(response, """attrs: 'attr="im an attr"'""")
+
+    def test_multiline_cvar_values(self):
+        self.create_template(
+            "multiline_cvar_values_view.html",
+            """<c-multiline-cvar-values />""",
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/multiline_cvar_values.html",
+            """
+                <c-vars multiline="line1
+                line2" />
+            """,
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertTrue(response.status_code == 200)
+
+    def test_assigning_cvars_as_empty_strings(self):
+        self.create_template(
+            "empty_string_cvars_view.html",
+            """<c-empty-string-cvars />""",
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/empty_string_cvars.html",
+            """
+                <c-vars test="" />
+                
+                {% if test == "" %}got it{% endif %}
+            """,
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertTrue(response.status_code == 200)
+            self.assertContains(response, "got it")
+
+    def test_class_attrs_dont_come_through_as_lists(self):
+        self.create_template(
+            "empty_class_attrs_view.html",
+            """<c-empty-class-attrs />""",
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/empty_class_attrs.html",
+            """
+                <c-vars class="" />
+                {{ class }}
+                
+            """,
+        )
+
+        ## {% if class == "" %}got it{% endif %}
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            print(response.content.decode())
+            self.assertTrue(response.status_code == 200)
+            self.assertContains(response, "got it")

--- a/django_cotton/tests/test_cvars.py
+++ b/django_cotton/tests/test_cvars.py
@@ -232,15 +232,11 @@ class CvarTests(CottonTestCase):
             "cotton/empty_class_attrs.html",
             """
                 <c-vars class="" />
-                {{ class }}
                 
+                {% if class == "" %}got it{% endif %}
             """,
         )
 
-        ## {% if class == "" %}got it{% endif %}
-
         with self.settings(ROOT_URLCONF=self.url_conf()):
             response = self.client.get("/view/")
-            print(response.content.decode())
-            self.assertTrue(response.status_code == 200)
             self.assertContains(response, "got it")


### PR DESCRIPTION
Fixed

- `class` attributes we being passed a string from the compiler
- empty string attributes generated uncaught IndexError from attempting to resolve