### PR TITLE
Fixed string attributes being parsed as a template variables

### DIFF
--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -47,10 +47,7 @@ class CottonComponentNode(Node):
                 except UnprocessableDynamicAttr:
                     component_data["attrs"].unprocessable(key)
             else:
-                try:
-                    component_data["attrs"][key] = Variable(value).resolve(context)
-                except (VariableDoesNotExist, IndexError):
-                    component_data["attrs"][key] = value
+                component_data["attrs"][key] = value
 
         # Render the nodelist to process any slot tags and vars
         default_slot = self.nodelist.render(context)

--- a/django_cotton/tests/test_attributes.py
+++ b/django_cotton/tests/test_attributes.py
@@ -399,3 +399,31 @@ class AttributeHandlingTests(CottonTestCase):
         with self.settings(ROOT_URLCONF=self.url_conf()):
             response = self.client.get("/view/")
             self.assertContains(response, """'{"id": "1"}'""")
+
+    def test_string_attributes_are_not_parsed_as_variables(self):
+        self.create_template(
+            "cotton/string_attrs.html",
+            """
+                {% if string_attr == "world" %}
+                    This should not occur
+                {% endif %}
+            
+                {% if string_attr == "hello" %}
+                    It's hello
+                {% endif %}
+            """,
+        )
+
+        self.create_template(
+            "string_attrs_view.html",
+            """
+                <c-string-attrs string_attr="hello" />
+            """,
+            "view/",
+            context={"hello": "world"},
+        )
+
+        # Override URLconf
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "It's hello")


### PR DESCRIPTION
It was discovered that string attributes were first being parsed as a variable, if there was a variable in context with the attribute value, it was being assigned. This behaviour has been cancelled and strings will always be sent 'as is'.