### PR TITLE
reinstated isolated context

### DIFF
--- a/dev/example_project/example_project/templates/simple_native.html
+++ b/dev/example_project/example_project/templates/simple_native.html
@@ -1,1 +1,1 @@
-{% for d in data %}<h2>{% include 'benchmarks/native_include.html' %}</h2>{% endfor %}
+{% for d in data %}<h2>{% include 'benchmarks/native_include.html' only %}</h2>{% endfor %}

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -4,8 +4,11 @@ from typing import Union
 from django.conf import settings
 from django.template import Library
 from django.template.base import (
+    Variable,
+    VariableDoesNotExist,
     Node,
 )
+from django.template.context import ContextDict, Context
 from django.template.loader import get_template
 
 from django_cotton.utils import get_cotton_data
@@ -52,10 +55,10 @@ class CottonComponentNode(Node):
 
         # Prepare the cotton-specific data
         component_state = {
-            "attrs": component_data["attrs"],
-            "slot": default_slot,
             **component_data["slots"],
             **component_data["attrs"].make_attrs_accessible(),
+            "attrs": component_data["attrs"],
+            "slot": default_slot,
             "cotton_data": cotton_data,
         }
 

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -4,8 +4,6 @@ from typing import Union
 from django.conf import settings
 from django.template import Library
 from django.template.base import (
-    Variable,
-    VariableDoesNotExist,
     Node,
 )
 from django.template.loader import get_template
@@ -58,16 +56,16 @@ class CottonComponentNode(Node):
             "slot": default_slot,
             **component_data["slots"],
             **component_data["attrs"].make_attrs_accessible(),
+            "cotton_data": cotton_data,
         }
 
         template = self._get_cached_template(context, component_data["attrs"])
-
-        # Render the template with the new context
-        with context.push(**component_state):
-            output = template.render(context)
-
-        # Pop the component from the stack
+        output = template.render(context.new(component_state))
         cotton_data["stack"].pop()
+
+        # if not isolated, future 'only' support?:
+        # with context.push(component_state):
+        #     output = template.render(context)
 
         return output
 

--- a/django_cotton/tests/test_basic.py
+++ b/django_cotton/tests/test_basic.py
@@ -102,3 +102,22 @@ class BasicComponentTests(CottonTestCase):
                 response,
                 """My template path was not specified in settings!""",
             )
+
+    def test_components_have_isolated_context(self):
+        self.create_template(
+            "cotton/isolated_context.html",
+            """{{ outer }}""",
+        )
+
+        self.create_template(
+            "isolated_context_view.html",
+            """
+            <c-isolated-context />
+            """,
+            "view/",
+            context={"outer": "Outer content"},
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertNotContains(response, "Outer content")


### PR DESCRIPTION
We lost isolated context in a recent change (like django's native `only` on the `{% include %}`.

This PR brings it back, with test to ensure functionality.