### PR TITLE
reverted isolated context

### DIFF
--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -63,12 +63,14 @@ class CottonComponentNode(Node):
         }
 
         template = self._get_cached_template(context, component_data["attrs"])
-        output = template.render(context.new(component_state))
-        cotton_data["stack"].pop()
+        # excludes builtin + custom context processors
+        # output = template.render(context.new(component_state))
 
-        # if not isolated, future 'only' support?:
-        # with context.push(component_state):
-        #     output = template.render(context)
+        # provides global
+        with context.push(component_state):
+            output = template.render(context)
+
+        cotton_data["stack"].pop()
 
         return output
 

--- a/django_cotton/tests/test_basic.py
+++ b/django_cotton/tests/test_basic.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 from django_cotton.tests.utils import CottonTestCase
 
 
@@ -103,11 +105,12 @@ class BasicComponentTests(CottonTestCase):
                 """My template path was not specified in settings!""",
             )
 
+    @skip("Not implemented")
     def test_components_have_isolated_context(self):
         self.create_template(
             "cotton/isolated_context.html",
             """{{ outer }}""",
-        )
+        )git
 
         self.create_template(
             "isolated_context_view.html",

--- a/django_cotton/tests/test_basic.py
+++ b/django_cotton/tests/test_basic.py
@@ -110,8 +110,7 @@ class BasicComponentTests(CottonTestCase):
         self.create_template(
             "cotton/isolated_context.html",
             """{{ outer }}""",
-        )git
-
+        )
         self.create_template(
             "isolated_context_view.html",
             """


### PR DESCRIPTION
The previous version isolates too much of the original context. This needs more time to work on a suitable solution to isolate context, for now we're reverting the behaviour.