### PR TITLE
Only isolates context

### DIFF
--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -111,11 +111,24 @@ class CottonComponentNode(Node):
         return value
 
 
+class IsolatedCottonComponentNode(CottonComponentNode):
+    def render(self, context):
+        isolated_context = Context({})
+        return super().render(isolated_context)
+
+
 def cotton_component(parser, token):
     bits = token.split_contents()[1:]
     component_name = bits[0]
     attrs = {}
+
+    node_class = CottonComponentNode
+
     for bit in bits[1:]:
+        if bit == "only":
+            # if we see `only` we use IsolatedCottonComponentNode
+            node_class = IsolatedCottonComponentNode
+            continue
         try:
             key, value = bit.split("=")
             attrs[key] = value
@@ -125,4 +138,4 @@ def cotton_component(parser, token):
     nodelist = parser.parse(("endc",))
     parser.delete_first_token()
 
-    return CottonComponentNode(component_name, nodelist, attrs)
+    return node_class(component_name, nodelist, attrs)

--- a/django_cotton/tests/test_attributes.py
+++ b/django_cotton/tests/test_attributes.py
@@ -296,7 +296,7 @@ class AttributeHandlingTests(CottonTestCase):
     def test_loader_preserves_duplicate_attributes(self):
         compiled = get_compiled("""<a href="#" class="test" class="test2">hello</a>""")
 
-        self.assertEquals(
+        self.assertEqual(
             compiled,
             """<a href="#" class="test" class="test2">hello</a>""",
         )

--- a/django_cotton/tests/test_slots.py
+++ b/django_cotton/tests/test_slots.py
@@ -69,7 +69,7 @@ class SlotTests(CottonTestCase):
             """
         )
 
-        self.assertEquals(
+        self.assertEqual(
             compiled,
             """{% vars var1="string with space" %}
             content


### PR DESCRIPTION
I added the ability to add `only` to a component to isolate the components context from the parent (similar to what django implements for include: https://docs.djangoproject.com/en/5.1/ref/templates/builtins/#include)

with a simple component:

`simple.html`
-------------
`<a class="{{ class|default:"donttouch" }}">test</a>`

this component, with parent context `{"class":"herebedragons"}`
will render (as normal)
`<c-simple />` as `<a class="herebedragons">test</a>`

whereas
`<c-simple only />` (with the same parent context `{"class":"herebedragons"}`) renders as `<a class="donttouch">test</a>`


I think the tests I added are sufficient but I'm not 100% sure.
