### PR TITLE
Htmx vals support - added another test

### DIFF
--- a/django_cotton/tests/test_attributes.py
+++ b/django_cotton/tests/test_attributes.py
@@ -408,6 +408,36 @@ class AttributeHandlingTests(CottonTestCase):
             response = self.client.get("/view/")
             self.assertContains(response, """'{"id": "1"}'""")
 
+    def test_htmx_vals_again(self):
+        self.create_template(
+            "cotton/htmx_vals.html",
+            """
+            <div {{ attrs }}><div>
+            """,
+        )
+
+        self.create_template(
+            "htmx_vals.html",
+            """
+            <c-htmx-vals
+                hx-post="/root"
+                hx-trigger="click"
+                hx-vals='{"use_block": "page-and-paging-controls"}'
+                only
+            />
+            """,
+            "htmx-vals/",
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/htmx-vals/")
+            self.assertContains(response, """hx-vals='{"use_block": "page-and-paging-controls"}'""")
+            self.assertContains(response, 'hx-post="/root"')
+            self.assertContains(response, 'hx-trigger="click"')
+            self.assertNotContains(response, 'hx-vals="')
+            self.assertNotContains(response, "hx-vals=`")
+            self.assertNotContains(response, "only")
+
     def test_string_attributes_are_not_parsed_as_variables(self):
         self.create_template(
             "cotton/string_attrs.html",

--- a/django_cotton/tests/test_attributes.py
+++ b/django_cotton/tests/test_attributes.py
@@ -417,26 +417,24 @@ class AttributeHandlingTests(CottonTestCase):
         )
 
         self.create_template(
-            "htmx_vals.html",
+            "htmx_vals_view.html",
             """
             <c-htmx-vals
                 hx-post="/root"
                 hx-trigger="click"
                 hx-vals='{"use_block": "page-and-paging-controls"}'
-                only
             />
             """,
-            "htmx-vals/",
+            "htmx-vals-view/",
         )
 
         with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/htmx-vals/")
+            response = self.client.get("/htmx-vals-view/")
             self.assertContains(response, """hx-vals='{"use_block": "page-and-paging-controls"}'""")
             self.assertContains(response, 'hx-post="/root"')
             self.assertContains(response, 'hx-trigger="click"')
             self.assertNotContains(response, 'hx-vals="')
             self.assertNotContains(response, "hx-vals=`")
-            self.assertNotContains(response, "only")
 
     def test_string_attributes_are_not_parsed_as_variables(self):
         self.create_template(


### PR DESCRIPTION
I've just added another (passing) test - better support hx-vals with single quotes to support #176 