### PR TITLE
allow referencing previous c-vars when resolving

### DIFF
--- a/django_cotton/templatetags/_vars.py
+++ b/django_cotton/templatetags/_vars.py
@@ -29,7 +29,8 @@ class CottonVarsNode(Node):
                 if key not in attrs.exclude_unprocessable():
                     if key.startswith(":"):
                         try:
-                            vars[key[1:]] = DynamicAttr(value, is_cvar=True).resolve(context)
+                            with context.push({**vars, **attrs.make_attrs_accessible()}):
+                                vars[key[1:]] = DynamicAttr(value, is_cvar=True).resolve(context)
                         except UnprocessableDynamicAttr:
                             pass
                     else:

--- a/django_cotton/templatetags/_vars.py
+++ b/django_cotton/templatetags/_vars.py
@@ -50,31 +50,6 @@ class CottonVarsNode(Node):
         with context.push({**vars, **attrs.make_attrs_accessible(), "attrs": attrs}):
             output = self.nodelist.render(context)
 
-            return output
-        
-
-        for key, value in self.var_dict.items():
-            if key not in attrs.exclude_unprocessable():
-                if key.startswith(":"):
-                    try:
-                        vars[key[1:]] = DynamicAttr(value, is_cvar=True).resolve(context)
-                    except UnprocessableDynamicAttr:
-                        pass
-                else:
-                    try:
-                        resolved_value = Variable(value).resolve(context)
-                    except (VariableDoesNotExist, IndexError):
-                        resolved_value = value
-                    attrs[key] = resolved_value
-            attrs.exclude_from_string_output(key)
-
-        # Process cvars without values
-        for empty_var in self.empty_vars:
-            attrs.exclude_from_string_output(empty_var)
-
-        with context.push({**vars, **attrs.make_attrs_accessible(), "attrs": attrs}):
-            output = self.nodelist.render(context)
-
         return output
 
 

--- a/django_cotton/tests/test_cvars.py
+++ b/django_cotton/tests/test_cvars.py
@@ -369,7 +369,7 @@ class CvarTests(CottonTestCase):
 
     def test_cvars_referening_other_cvars(self):
         self.create_template(
-            "attribute_priority_view.html",
+            "vars_refs.html",
             """<c-var-refs />""",
             "view/",
         )

--- a/django_cotton/tests/test_cvars.py
+++ b/django_cotton/tests/test_cvars.py
@@ -364,3 +364,23 @@ class CvarTests(CottonTestCase):
             response = self.client.get("/view/")
             self.assertContains(response, "expected")
             self.assertNotContains(response, "not")
+
+    def test_cvars_referening_other_cvars(self):
+        self.create_template(
+            "attribute_priority_view.html",
+            """<c-var-refs />""",
+            "view/",
+        )
+
+        self.create_template(
+            "cotton/var_refs.html",
+            """
+                <c-vars first="1" :second=first :third={{second|add:first}} />
+                
+                First: {{ first }}, Second: {{ second }}, Third: {{ third }}
+            """,
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "First: 1, Second: 1, Third: 2")


### PR DESCRIPTION
This allows you to split up complex logic in cvars into multiple steps and avoid repeating logic.

Here's an example where the 2nd var references the value of the 1st var.

```xml
<c-vars
    :slot_is_empty="{{ slot|length|yesno:'false,true' }}"
    :make_square="{{ square|default_if_none:slot_is_empty }}" 
>/
```