### PR TITLE
raise value error when multiple c-vars provided

### DIFF
--- a/django_cotton/compiler_regex.py
+++ b/django_cotton/compiler_regex.py
@@ -121,13 +121,26 @@ class CottonCompiler:
         return replacements
 
     def process_c_vars(self, html: str) -> Tuple[str, str]:
-        """Extract c-vars content and remove c-vars tags from the html"""
-        match = self.c_vars_pattern.search(html)
+        """
+        Extract c-vars content and remove c-vars tags from the html.
+        Raises ValueError if more than one c-vars tag is found.
+        """
+        # Find all matches of c-vars tags
+        matches = list(self.c_vars_pattern.finditer(html))
+
+        if len(matches) > 1:
+            raise ValueError(
+                f"Multiple c-vars tags found in component template. Only one c-vars tag is allowed per template."
+            )
+
+        # Process single c-vars tag if present
+        match = matches[0] if matches else None
         if match:
             attrs = match.group(1)
             vars_content = f"{{% vars {attrs.strip()} %}}"
             html = self.c_vars_pattern.sub("", html)  # Remove all c-vars tags
             return vars_content, html
+
         return "", html
 
     def process(self, html: str) -> str:

--- a/django_cotton/tests/test_compiler.py
+++ b/django_cotton/tests/test_compiler.py
@@ -70,3 +70,29 @@ class CompileTests(CottonTestCase):
             "{% cotton_verbatim %}" not in compiled,
             "Compilation should not leave {% cotton_verbatim %} tags in the output",
         )
+
+    def test_raises_error_on_duplicate_cvars(self):
+        with self.assertRaises(ValueError) as cm:
+            get_compiled(
+                """
+                <c-vars />
+                <c-vars />
+            """
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "Multiple c-vars tags found in component template. Only one c-vars tag is allowed per template.",
+        )
+
+    def test_raises_on_slots_without_name(self):
+        with self.assertRaises(ValueError) as cm:
+            get_compiled(
+                """
+                <c-slot />
+            """
+            )
+
+        self.assertTrue(
+            "c-slot tag must have a name attribute:" in str(cm.exception),
+        )


### PR DESCRIPTION
Cotton will now raise a ValueError when multiple c-vars are used, to make it clear only one tag is supported. This is due to a couple of instances recently where users were instinctively thinking the usage of multiple was supported.