### PR TITLE
added support for hyphenated component filenames

### DIFF
--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -100,7 +100,13 @@ class CottonComponentNode(Node):
                 )
             component_name = is_
 
-        component_tpl_path = component_name.replace(".", "/").replace("-", "_")
+        component_tpl_path = component_name.replace(".", "/")
+
+        # Cotton by default will look for snake_case version of comp names. This can be configured to allow hyphenated names.
+        snaked_cased_named = getattr(settings, "COTTON_SNAKE_CASED_NAMES", True)
+        if snaked_cased_named:
+            component_tpl_path = component_tpl_path.replace("-", "_")
+
         cotton_dir = getattr(settings, "COTTON_DIR", "cotton")
         return f"{cotton_dir}/{component_tpl_path}.html"
 

--- a/django_cotton/tests/test_basic.py
+++ b/django_cotton/tests/test_basic.py
@@ -1,4 +1,6 @@
-from django_cotton.tests.utils import CottonTestCase
+from django.test import override_settings
+
+from django_cotton.tests.utils import CottonTestCase, get_rendered
 
 
 class BasicComponentTests(CottonTestCase):
@@ -186,3 +188,18 @@ class BasicComponentTests(CottonTestCase):
             self.assertContains(response, "From parent comp scope: ''")
             self.assertContains(response, "From view context scope: ''")
             self.assertContains(response, "Direct attribute: 'yes'")
+
+    @override_settings(COTTON_SNAKE_CASED_NAMES=False)
+    def test_hyphen_naming_convention(self):
+        self.create_template(
+            "cotton/some-subfolder/hyphen-naming-convention.html",
+            "I have a hyphenated component name",
+        )
+
+        html = """
+            <c-some-subfolder.hyphen-naming-convention />
+        """
+
+        rendered = get_rendered(html)
+
+        self.assertTrue("I have a hyphenated component name" in rendered)

--- a/django_cotton/tests/test_compiler.py
+++ b/django_cotton/tests/test_compiler.py
@@ -1,3 +1,4 @@
+
 from django_cotton.tests.utils import CottonTestCase, get_compiled
 
 

--- a/django_cotton/tests/utils.py
+++ b/django_cotton/tests/utils.py
@@ -58,6 +58,12 @@ class CottonTestCase(TestCase):
 
     def create_template(self, name, content, url=None, context={}):
         """Create a template file in the temporary directory and return the path"""
+
+        # To test the non-default of allowing non-snake-cased names
+        snake_cased_names = getattr(settings, "COTTON_SNAKE_CASED_NAMES", True)
+        if not snake_cased_names:
+            name = name.replace("_", "-")
+
         path = os.path.join(self.temp_dir, name)
 
         if os.path.exists(path):

--- a/docs/docs_project/docs_project/templates/components.html
+++ b/docs/docs_project/docs_project/templates/components.html
@@ -93,6 +93,10 @@
 </c-slot>
 </c-snippet>
 
+    <c-note>
+        Component filenames should be <c-highlight>snake_cased</c-highlight> by default, but you can change this behaviour by adding <code>COTTON_SNAKE_CASED_NAMES</code> to <code>False</code> in your settings.py, <a href="{% url 'configuration' %}">read more</a>.
+    </c-note>
+
     <c-hr />
 
     <h2 id="dynamic-attributes">4. Dynamic Attributes with ":"</h2>

--- a/docs/docs_project/docs_project/templates/configuration.html
+++ b/docs/docs_project/docs_project/templates/configuration.html
@@ -3,9 +3,43 @@
 
     <p>The following configuration can be provided in your `settings.py`:</p>
 
-    <h4>COTTON_DIR</h4>
-    <p>str (default: 'cotton')</p>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div>
+            <code>COTTON_DIR</code>
+            <div>str (default: 'cotton')</div>
+        </div>
+        <div>
+            Change the default path in your templates directory where cotton components can be placed, for example "components".
+        </div>
+    </div>
 
-    <p>Change the default path in your templates directory where cotton components can be placed, for example "components".</p>
+    <c-hr />
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div>
+            <code>COTTON_SNAKE_CASED_NAMES</code>
+            <div>bool (default: True)</div>
+        </div>
+        <div>
+            By default cotton will look for snake case versions of your component names. To turn this behaviour off (useful if you want to permit hyphenated filenames).
+
+            <div class="mb-4 mt-4">
+                <h6 class="mb-1">Example:</h6>
+                <code>{{ '<c-my-button />'|force_escape }}</code>
+            </div>
+
+            <div class="mb-4">
+                <h6>As <code>True</code> (default)</h6>
+                Filepath: `cotton/my_button.html`
+            </div>
+
+            <div>
+                <h6>As <code>False</code></h6>
+                Filepath: `cotton/my-button.html`
+            </div>
+
+        </div>
+    </div>
+
 
 </c-layouts.with-sidebar>

--- a/docs/docs_project/docs_project/templates/configuration.html
+++ b/docs/docs_project/docs_project/templates/configuration.html
@@ -21,9 +21,9 @@
             <div>bool (default: True)</div>
         </div>
         <div>
-            By default cotton will look for snake case versions of your component names. To turn this behaviour off (useful if you want to permit hyphenated filenames).
+            <div class="mb-4">By default cotton will look for snake case versions of your component names. To turn this behaviour off (useful if you want to permit hyphenated filenames).</div>
 
-            <div class="mb-4 mt-4">
+            <div class="mb-4">
                 <h6 class="mb-1">Example:</h6>
                 <code>{{ '<c-my-button />'|force_escape }}</code>
             </div>

--- a/docs/docs_project/docs_project/templates/cotton/hr.html
+++ b/docs/docs_project/docs_project/templates/cotton/hr.html
@@ -1,1 +1,1 @@
-<div {{ attrs }} class="h-[2px] bg-yellow-900 bg-opacity-10 my-8 w-full dark:bg-gray-700"></div>
+<div {{ attrs }} class="h-[1px] bg-yellow-900 bg-opacity-10 my-8 w-full dark:bg-gray-700"></div>

--- a/docs/docs_project/docs_project/templates/cotton/note.html
+++ b/docs/docs_project/docs_project/templates/cotton/note.html
@@ -1,3 +1,3 @@
-<div class="mt-6 border border-teal-600 rounded-lg px-8 py-5 dark:border dark:bg-transparent">
+<div class="mt-6 border-2 border-teal-500 bg-teal-500/10 rounded-lg px-8 py-5 dark:borderdark:bg-transparent">
     {{ slot }}
 </div>

--- a/docs/docs_project/docs_project/templates/cotton/note.html
+++ b/docs/docs_project/docs_project/templates/cotton/note.html
@@ -1,3 +1,3 @@
-<div class="mt-6 border-2 border-teal-500 bg-teal-500/10 rounded-lg px-8 py-5 dark:borderdark:bg-transparent">
+<div class="mt-6 border-2 border-teal-500 bg-teal-500/10 rounded-lg px-8 py-5">
     {{ slot }}
 </div>

--- a/docs/docs_project/docs_project/templates/cotton/sidebar_block.html
+++ b/docs/docs_project/docs_project/templates/cotton/sidebar_block.html
@@ -1,4 +1,4 @@
-<div class="py-4 {{ class }} border-b border-yellow-900 border-opacity-15 dark:border-gray-700 dark:border-opacity-100 last:border-0 first:pt-0 leading-7">
+<div class="py-4 {{ class }} first:pt-0 leading-7">
     {% if title %}
         <c-sidebar-heading>{{ title }}</c-sidebar-heading>
     {% endif %}

--- a/docs/docs_project/docs_project/templates/cotton/sidebar_heading.html
+++ b/docs/docs_project/docs_project/templates/cotton/sidebar_heading.html
@@ -1,1 +1,1 @@
-<div class="dark:text-white text-[#1a384a] dark:opacity-35 text-yellow-800 brightness-65 text-opacity-50 font-semibold uppercase text-[14px] mb-2 tracking-wider">{{ slot }}</div>
+<div class="dark:text-white dark:opacity-35 text-yellow-900/40 font-semibold uppercase text-[14px] mb-2 tracking-wider">{{ slot }}</div>

--- a/docs/docs_project/docs_project/templates/home.html
+++ b/docs/docs_project/docs_project/templates/home.html
@@ -20,7 +20,7 @@
                 <div class="w-full shrink-0"></div>
                 <span class="pt-0 md:pt-5 clear-both flex-wrap inline-flex justify-center items-center space-x-2">
                     <span class="">Hello</span>
-                    <span class="shrink-0 px-3 py-1 bg-teal-600 font-mono text-xl sm:text-2xl md:text-4xl rounded-lg text-white inline-block font-normal leading-normal">{{ '&lt;c-component />' }}</span>
+                    <span class="shrink-0 px-3 py-1 bg-teal-500/10 border-[3px] border-teal-600 font-mono text-xl sm:text-2xl md:text-4xl rounded-3xl text-teal-600 dark:text-white inline-block font-normal leading-normal">{{ '<c-comp />'|force_escape }}</span>
                 </span>
             </h1>
 
@@ -32,7 +32,7 @@
 
         <div class="grid md:grid-cols-2 gap-4">
             <div class="col-span-1 flex flex-col overflow-x-auto">
-                <h2 class="!font-normal !text-xl mb-3 mt-0 text-center"><span class="font-semibold">Before:</span> Strongly Coupled, Verbose</h2>
+                <h2 class="!font-normal !text-lg mb-3 mt-0 text-center"><span class="font-semibold">Before:</span> Strongly Coupled, Verbose</h2>
                 <div class="flex h-full rounded-xl overflow-hidden">
                     <c-demo.snippet-tabs labels="view.html|product_layout.html" tabs_id="compare">
                         <div class="flex flex-col h-full" x-show="active === 0">
@@ -88,7 +88,7 @@ Item Title
                 </div>
             </div>
             <div class="col-span-1 rounded-lg overflow-hidden  flex flex-col">
-                <h2 class="!font-normal !text-xl mb-3 mt-0 text-center"><span class="font-semibold">After:</span> Decoupled, Clean &amp; Re-usable</h2>
+                <h2 class="!font-normal !text-lg mb-3 mt-0 text-center"><span class="font-semibold">After:</span> Decoupled, Clean &amp; Re-usable</h2>
                 <div class="flex h-full rounded-xl overflow-hidden">
                     <c-demo.snippet-tabs labels="view.html|product.html" tabs_id="compare">
                         <div class="flex flex-col h-full" x-show="active === 0">


### PR DESCRIPTION
References #208 

Adds a `COTTON_SNAKE_CASED_NAMES` config option to disable the default behaviour to look for snake cased versions for component names, thus allowing hyphenated component file names.