### PR TITLE
Added index.html pattern

### DIFF
--- a/django_cotton/tests/test_misc.py
+++ b/django_cotton/tests/test_misc.py
@@ -3,57 +3,7 @@ from django.test import override_settings
 from django_cotton.tests.utils import CottonTestCase, get_rendered
 
 
-class BasicComponentTests(CottonTestCase):
-    def test_component_is_rendered(self):
-        self.create_template(
-            "cotton/render.html",
-            """<div class="i-am-component">{{ slot }}</div>""",
-        )
-
-        self.create_template(
-            "view.html",
-            """<c-render>Hello, World!</c-render>""",
-            "view/",
-        )
-
-        # Override URLconf
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertContains(response, '<div class="i-am-component">')
-            self.assertContains(response, "Hello, World!")
-
-    def test_nested_rendering(self):
-        self.create_template(
-            "cotton/parent.html",
-            """
-                <div class="i-am-parent">
-                    {{ slot }}
-                </div>            
-            """,
-        )
-
-        self.create_template(
-            "cotton/child.html",
-            """
-                <div class="i-am-child"></div>
-            """,
-        )
-
-        self.create_template(
-            "cotton/nested_render_view.html",
-            """
-            <c-parent>
-                <c-child>d</c-child>
-            </c-parent>            
-            """,
-            "view/",
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertContains(response, '<div class="i-am-parent">')
-            self.assertContains(response, '<div class="i-am-child">')
-
+class MiscComponentTests(CottonTestCase):
     def test_cotton_directory_can_be_configured(self):
         custom_dir = "components"
 
@@ -73,24 +23,6 @@ class BasicComponentTests(CottonTestCase):
             response = self.client.get("/view/")
             self.assertContains(response, '<div class="i-am-component">')
             self.assertContains(response, "Hello, World!")
-
-    def test_self_closing_is_rendered(self):
-        self.create_template("cotton/self_closing.html", """I self closed!""")
-        self.create_template(
-            "self_closing_view.html",
-            """
-                1: <c-self-closing/>
-                2: <c-self-closing />
-                3: <c-self-closing  />
-            """,
-            "view/",
-        )
-
-        with self.settings(ROOT_URLCONF=self.url_conf()):
-            response = self.client.get("/view/")
-            self.assertContains(response, "1: I self closed!")
-            self.assertContains(response, "2: I self closed!")
-            self.assertContains(response, "3: I self closed!")
 
     def test_loader_scans_all_app_directories(self):
         self.create_template(
@@ -221,3 +153,17 @@ class BasicComponentTests(CottonTestCase):
         self.assertTrue("I'm from app templates!" in rendered)
         self.assertTrue("I'm from project root templates!" in rendered)
         self.assertTrue("i'm sub in project root" in rendered)
+
+    def test_index_file_access(self):
+        self.create_template(
+            "cotton/accordion/index.html",
+            "I'm an index file!",
+        )
+
+        html = """
+            <c-accordion />
+        """
+
+        rendered = get_rendered(html)
+
+        self.assertTrue("I'm an index file!" in rendered)


### PR DESCRIPTION
This PR introduces ability to choose a default component when calling a directory path by using an index.html.

Before:

```
- cotton
  - comp
    - header.html
    - main.html


<c-comp.main>
  <c-comp.header />
</c-comp.main>
```

After:

```
- cotton
  - comp
    - header.html
    - index.html


<c-comp>
  <c-comp.header />
</c-comp>
```