### PR TITLE
turned off context isolation by default

### DIFF
--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -42,7 +42,6 @@ class CottonComponentNode(Node):
                 component_data["attrs"][key] = True
             elif key.startswith("::"):  # Escaping 1 colon e.g for shorthand alpine
                 key = key[1:]
-                # component_data["slots"][key] = value
                 component_data["attrs"][key] = value
             elif key.startswith(":"):
                 key = key[1:]
@@ -71,7 +70,7 @@ class CottonComponentNode(Node):
             # Complete isolation
             output = template.render(Context(component_state))
         else:
-            if getattr(settings, "COTTON_ENABLE_CONTEXT_ISOLATION", True):
+            if getattr(settings, "COTTON_ENABLE_CONTEXT_ISOLATION", False) is True:
                 # Default - partial isolation
                 new_context = self._create_partial_context(context, component_state)
                 output = template.render(new_context)

--- a/django_cotton/tests/test_context_isolation.py
+++ b/django_cotton/tests/test_context_isolation.py
@@ -96,6 +96,7 @@ class ContextIsolationTests(CottonTestCase):
             response = self.client.get("/view/")
             self.assertContains(response, "blee")
 
+    @override_settings(COTTON_ENABLE_CONTEXT_ISOLATION=True)
     def test_context_isolated_by_default(self):
         self.create_template(
             "cotton/receiver.html",


### PR DESCRIPTION
Reverting context isolation due to context processors being generated for each component render as observed [here](#269 )