### PR TITLE
Run tests with multiple Python / Django versions combinations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
-        django: ["4.2", "5.0", "5.1"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
+        django: ["4.2", "5.0", "5.1", "5.2"]
+        exclude:
+          - { python: "3.13", django: "4.2" }
+          - { python: "3.13", django: "5.0" }
 
     name: Tests - python ${{ matrix.python }} × django ${{ matrix.django }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,20 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+        django: ["4.2", "5.0", "5.1"]
+
+    name: Tests - python ${{ matrix.python }} × django ${{ matrix.django }}
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
-          docker build -f dev/docker/Dockerfile -t cotton-test-app dev/example_project
+          docker build -f dev/docker/Dockerfile --build-arg PYTHON_VERSION=${{ matrix.python }} --build-arg DJANGO_VERSION=${{ matrix.django }} -t cotton-test-app dev/example_project
 
       - name: Start Container
         run: |

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -23,6 +23,6 @@ COPY . /app/
 # Install project dependencies
 RUN poetry config virtualenvs.create false \
     && poetry install \
-    && pip install -U "django==$DJANGO_VERSION.*"
+    && pip install -U --pre "django==$DJANGO_VERSION.*"
 
 CMD [ "python", "manage.py", "runserver", "0.0.0.0:8000" ]

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,6 +1,8 @@
+ARG PYTHON_VERSION=3.12
 # Use an official Python runtime as a base image
-FROM python:3.12-slim-bookworm
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
+ARG DJANGO_VERSION=4.2
 # Setup env
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_NO_CACHE_DIR=off \
@@ -20,6 +22,7 @@ COPY . /app/
 
 # Install project dependencies
 RUN poetry config virtualenvs.create false \
-    && poetry install
+    && poetry install \
+    && pip install -U "django==$DJANGO_VERSION.*"
 
 CMD [ "python", "manage.py", "runserver", "0.0.0.0:8000" ]

--- a/dev/example_project/pyproject.toml
+++ b/dev/example_project/pyproject.toml
@@ -9,5 +9,5 @@ description = "Development and test app for the django package."
 authors = ["Will Abbott <willabb83@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10"
 Django = "^5.1"

--- a/django_cotton/tests/test_template_rendering.py
+++ b/django_cotton/tests/test_template_rendering.py
@@ -1,3 +1,6 @@
+import unittest
+
+import django
 from django_cotton.tests.utils import CottonTestCase
 from django_cotton.tests.utils import get_compiled
 
@@ -194,6 +197,7 @@ class TemplateRenderingTests(CottonTestCase):
         compiled = get_compiled(many_encoded_html_chars)
         self.assertTrue(many_encoded_html_chars in compiled)
 
+    @unittest.skipIf(django.VERSION < (5, 1), "Django 5.1+")
     def test_querystring_can_be_rendered(self):
         self.create_template("cotton/querystring.html", """{% querystring %}""")
         self.create_template(


### PR DESCRIPTION
Hello !

I recently tried to update Django version on a project to perform tests with upcoming 5.2 (LTS). Unfortunately, django-cotton will currently fail to install because of its too strict requirements definition `django = ">=4.2,<5.2"`.

While I was looking to understand this constraint, I realized that unit tests were currently ran only on Python 3.12 and with Django 5.1. This PR will update Dockerfile and Actions workflow to run tests against other versions.

I hope thiw will help to unleash cotton requirements and allow installing with Django 5.2 ;)

Best regards