### PR TITLE
Add support for Cotton Directives (c-if, c-elif, c-else, c-for)

### DIFF
--- a/django_cotton/cotton_loader.py
+++ b/django_cotton/cotton_loader.py
@@ -10,7 +10,7 @@ from django.utils._os import safe_join
 from django.template import Template
 from django.apps import apps
 
-from django_cotton.compiler_regex import CottonCompiler
+from django_cotton.compiler_regex import CottonCompiler, CottonDirectiveParser
 
 
 class Loader(BaseLoader):
@@ -18,6 +18,7 @@ class Loader(BaseLoader):
         super().__init__(engine)
         self.cotton_compiler = CottonCompiler()
         self.cache_handler = CottonTemplateCacheHandler()
+        self.directive_parser = CottonDirectiveParser()
         self.dirs = dirs
 
     def get_contents(self, origin):
@@ -28,7 +29,8 @@ class Loader(BaseLoader):
             return cached_content
 
         template_string = self._get_template_string(origin.name)
-
+        template_string = self.directive_parser.process(template_string)
+        
         if "<c-" not in template_string and "{% cotton_verbatim" not in template_string:
             compiled = template_string
         else:

--- a/django_cotton/tests/test_directives.py
+++ b/django_cotton/tests/test_directives.py
@@ -1,0 +1,123 @@
+from django_cotton.tests.utils import CottonTestCase
+from django_cotton.cotton_loader import Loader as CottonLoader
+
+def get_parsed_directives(template_string: str) -> str:
+    return CottonLoader(engine=None).directive_parser.process(template_string)
+
+class CottonDirectivesTests(CottonTestCase):
+    def test_if_directive(self):
+        template = """
+            <div c-if="True">
+                one
+            </div>
+            
+            <div c-if="False">
+                two
+            </div>
+        """
+        parsed = get_parsed_directives(template)
+        self.assertRegex(parsed, r"{%\s*if True\s*%}")
+        self.assertRegex(parsed, r"{%\s*if False\s*%}")
+        
+        self.create_template(
+            "if_directive.html",
+            template,
+            "view/",
+        )
+       
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "one")
+            self.assertNotContains(response, "two")
+
+
+    def test_elif_directive(self):
+        template = """
+            <div c-if="False">one</div>
+            <div c-elif="True">two</div>
+            <div c-else>three</div>
+        """
+        parsed = get_parsed_directives(template)
+        self.assertRegex(parsed, r"{%\s*if False\s*%}")
+        self.assertRegex(parsed, r"{%\s*elif True\s*%}")
+        self.assertRegex(parsed, r"{%\s*else\s*%}")
+        
+        self.create_template(
+            "elif_directive.html",
+            template,
+            "view/",
+        )
+        
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertNotContains(response, "one")
+            self.assertContains(response, "two")
+            self.assertNotContains(response, "three")
+            
+    def test_else_directive(self):
+        template = """
+            <div c-if="False">one</div>
+            <div c-elif="False">two</div>
+            <div c-else>three</div>
+        """
+        parsed = get_parsed_directives(template)
+        self.assertRegex(parsed, r"{%\s*if False\s*%}")
+        self.assertRegex(parsed, r"{%\s*elif False\s*%}")
+        self.assertRegex(parsed, r"{%\s*else\s*%}")
+        
+        self.create_template(
+            "else_directive.html",
+            template,
+            "view/",
+        )
+        
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertNotContains(response, "one")
+            self.assertNotContains(response, "two")
+            self.assertContains(response, "three")
+       
+    def test_for_directive(self):
+        template = """
+            <ul c-for="number in '123'">
+                <li>{{ number }}</li>
+            </ul>
+        """
+        parsed = get_parsed_directives(template)
+        self.assertRegex(parsed, r"{%\s*for number in '123'\s*%}")
+        
+        self.create_template(
+           "for_directive.html",
+            template,
+            "view/",
+        )
+        
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "<li>1</li>")
+            self.assertContains(response, "<li>2</li>")
+            self.assertContains(response, "<li>3</li>")
+            
+    def test_nested_directives(self):
+        template = """
+            <div c-if="True">
+                <ul c-for="number in '123'">
+                    <li>{{ number }}</li>
+                </ul>
+            </div>
+        """
+        parsed = get_parsed_directives(template)
+        self.assertRegex(parsed, r"{%\s*if True\s*%}")
+        self.assertRegex(parsed, r"{%\s*for number in '123'\s*%}")
+        
+        self.create_template(
+           "nested_directives.html",
+            template,
+            "view/",
+        )
+        
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            self.assertContains(response, "<li>1</li>")
+            self.assertContains(response, "<li>2</li>")
+            self.assertContains(response, "<li>3</li>")


### PR DESCRIPTION
## About this proposal

This is a feature proposal introducing Cotton Directives — an HTML-based syntax for control flow in templates (`c-if`, `c-elif`, `c-else`, `c-for`). Let me know if you'd prefer this to be discussed in a separate thread first.

 Thanks for this great library — it's been a lot of fun to work with!

## Description

This PR introduces **Cotton Directives**, a better way to write control flow statements (`if`, `elif`, `else`, `for`) following django_cotton’s philosophy. These directives use HTML attributes such as `c-if` and `c-for`, which can be applied to **any HTML element**, not limited to Django Cotton components.

Currently, writing control flow in Django templates requires verbose template tags like `{% if %}`, `{% endif %}`, which can disrupt the HTML structure and developer experience.

This feature adds a cleaner, attribute-based syntax that aligns better with the design of django_cotton, enabling more readable and maintainable templates.

> **Note:** Cotton directives are completely optional. Developers can choose to stick with block tags, use directives, or combine both approaches. This feature simply adds a new possibility.

## How It Works

Cotton Directives are implemented as special HTML attributes (`c-if`, `c-elif`, `c-else`, `c-for`) that are parsed and translated into the equivalent Django template tag during the loader phase.

When the template is processed:

- The parser searches for elements with a directive.
- The element is wrapped with the appropriate `{% %}` Django template tag.
- The directive attribute is removed from the final HTML output to prevent duplication and avoid it being treated as a regular cotton attribute.

#### Example

```html
<div c-if="user.is_authenticated">
  <h1>Welcome, {{ user.username }}</h1>
</div>
```

Will be rendered as:

```html
{% if user.is_authenticated %}
<div>
  <h1>Welcome, {{ user.username }}</h1>
</div>
{% endif %}
```

> **Note:** Nested directives are fully supported. You can safely nest `c-if` inside `c-for`, or even multiple `c-if` blocks within each other.

#### Example

```html
<c-avatars>
  <c-avatar c-for="user in users">
    <c-image c-if="user.photo" :src="user.photo" />
    <c-icon c-elif="user.icon" :icon="user.icon" />
    <c-initials c-else :name="user.full_name" />
  </c-avatar>
</c-avatars>
```

Which renders to:

```html
<c-avatars>
  {% for user in users %}
  <c-avatar>
    {% if user.photo %}
    <c-image :src="user.photo" />
    {% elif user.icon %}
    <c-icon :icon="user.icon" />
    {% else %}
    <c-initials :name="user.full_name" />
    {% endif %}
  </c-avatar>
  {% endfor %}
</c-avatars>
```

> **Note:** Cotton directives are processed before cotton components, which means they do not affect the cotton compiler’s behavior.

Under the hood, the feature extends Python’s built-in `HTMLParser` to parse the template HTML string.

The parser detects elements containing the available directives, manages a stack-based structure to properly handle nested directives, and constructs the corresponding Django template tags around the matched HTML blocks.

## Extensibility

This initial implementation adds Cotton Directives specifically for control flow statements such as conditionals (`c-if`, `c-elif`, `c-else`) and loops (`c-for`). However, the design is intentionally extensible.

In the future, additional Cotton Directives can be introduced easily, since **any Django template block tag could potentially be represented as a Cotton Directive**.

## Performance

The Cotton Directives parser is blazing fast, thanks to Python’s built-in HTMLParser, which powers the feature.
In a test where 100 block tags were replaced with their respective directives (50 c-if and 50 c-for), the parser processed all 100 directives and transformed them into the corresponding Django block tags, adding only ~4ms to the final render time (measured on a notebook with an Intel i5-10210U processor).
