### PR TITLE
Typo: Show Size/ Shoe Size

### DIFF
--- a/docs/docs_project/docs_project/templates/form_fields.html
+++ b/docs/docs_project/docs_project/templates/form_fields.html
@@ -28,7 +28,7 @@
 {% endverbatim %}{% endcotton_verbatim %}</c-snippet>
 
 <c-snippet label="form_view.html">{% cotton_verbatim %}{% verbatim %}
-<c-input name="shoe_size" placeholder="Show Size" />
+<c-input name="shoe_size" placeholder="Shoe Size" />
 <c-input name="country" placeholder="Country" />
 <c-input name="age" placeholder="Age" />
 {% endverbatim %}{% endcotton_verbatim %}


### PR DESCRIPTION
Typo Code Block vs. HTML 

<img width="861" height="493" alt="image" src="https://github.com/user-attachments/assets/13651a4e-1ee5-4fcd-a635-d6ae02ad144b" />
