### PR TITLE
chore: Add support for quoteless dynamic attributes (ala DTL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,29 @@ By passing just the attribute name without a value, it will automatically be pro
 
 ### Passing Python data types
 
-Using the ':' to prefix an attribute tells Cotton we're passing a dynamic type down. We already know we can use this to send a variable, but you can also send basic python types, namely:
+Cotton supports two syntaxes for passing dynamic values:
+
+1. **Quoteless values**: `attr=value` - for simple values without spaces (like native Django)
+2. **Colon prefix**: `:attr="value"` - works for any expression
+
+```html
+<!-- Quoteless: for simple literals and variables -->
+<c-button enabled=True />
+<c-button enabled=False />
+<c-input value=my_variable />
+<c-counter start=42 />
+
+<!-- Colon prefix: required for complex expressions with spaces/quotes -->
+<c-select :options="['yes', 'no', 'maybe']" />
+<c-card :config="{'open': True}" />
+```
+
+Both approaches support:
 
 - Integers and Floats
 - None, True and False
-- Lists
-- Dictionaries
+- Lists and Dictionaries (colon prefix required)
+- Context variables
 
 This benefits a number of use-cases, for example if you have a select component that you want to provide the possible options from the parent:
 

--- a/django_cotton/compiler_regex.py
+++ b/django_cotton/compiler_regex.py
@@ -56,13 +56,15 @@ class Tag:
         for match in self.attr_pattern.finditer(self.attrs):
             key, quote, value, unquoted_value = match.groups()
             if value is None and unquoted_value is None:
+                # Boolean attribute (no value)
                 processed_attrs.append(key)
-            else:
-                actual_value = value if value is not None else unquoted_value
-                # Preserve the original quote character to avoid escaping issues
+            elif value is not None:
+                # Quoted value - preserve quotes
                 quote_char = quote if quote else '"'
-                # With nested tag support, all attributes can be passed directly
-                processed_attrs.append(f'{key}={quote_char}{actual_value}{quote_char}')
+                processed_attrs.append(f'{key}={quote_char}{value}{quote_char}')
+            else:
+                # Unquoted value - pass through WITHOUT quotes to preserve dynamic status
+                processed_attrs.append(f'{key}={unquoted_value}')
 
         attrs_str = " ".join(processed_attrs)
         return " " + attrs_str if attrs_str else "", "".join(extracted_attrs)

--- a/django_cotton/templatetags/__init__.py
+++ b/django_cotton/templatetags/__init__.py
@@ -1,6 +1,6 @@
 import ast
 from collections.abc import Mapping
-from typing import Set, Any, Dict, List
+from typing import Set, Any, Dict, List, Tuple
 
 from django.template import Variable, TemplateSyntaxError, Context
 from django.template.base import VariableDoesNotExist, Template
@@ -86,6 +86,27 @@ def strip_quotes_safely(value: Any) -> Any:
         elif value.startswith("'") and value.endswith("'") and len(value) >= 2:
             return value[1:-1]
     return value
+
+
+def strip_quotes_with_status(value: Any) -> Tuple[Any, bool]:
+    """
+    Strip surrounding quotes and return whether the value was originally quoted.
+
+    More efficient than calling a separate check then strip_quotes_safely(),
+    as it only checks the string once.
+
+    Args:
+        value: The value to strip quotes from
+
+    Returns:
+        Tuple of (stripped_value, was_quoted)
+    """
+    if type(value) is str:
+        if value.startswith('"') and value.endswith('"') and len(value) >= 2:
+            return value[1:-1], True
+        elif value.startswith("'") and value.endswith("'") and len(value) >= 2:
+            return value[1:-1], True
+    return value, False
 
 
 class UnprocessableDynamicAttr(Exception):

--- a/django_cotton/tests/unit/test_compiler.py
+++ b/django_cotton/tests/unit/test_compiler.py
@@ -123,3 +123,34 @@ class CompilerUnitTests(unittest.TestCase):
             )
 
         self.assertIn("c-slot tag must have a name attribute:", str(cm.exception))
+
+    def test_unquoted_attrs_preserved_in_compilation(self):
+        """Unquoted attrs should stay unquoted when HTML is compiled to template tag"""
+        compiled = get_compiled('<c-test disabled=True count=5 />')
+        self.assertIn('disabled=True', compiled)
+        self.assertIn('count=5', compiled)
+        # Should NOT wrap in quotes
+        self.assertNotIn('disabled="True"', compiled)
+        self.assertNotIn('count="5"', compiled)
+
+    def test_quoted_attrs_stay_quoted_in_compilation(self):
+        """Quoted attrs should stay quoted when compiled"""
+        compiled = get_compiled('<c-test disabled="True" count="5" />')
+        self.assertIn('disabled="True"', compiled)
+        self.assertIn('count="5"', compiled)
+
+    def test_mixed_quoted_unquoted_attrs_compilation(self):
+        """Both quoted and unquoted attrs in same component should be preserved correctly"""
+        compiled = get_compiled('<c-test quoted="string" unquoted=True />')
+        self.assertIn('quoted="string"', compiled)
+        self.assertIn('unquoted=True', compiled)
+        # Make sure unquoted isn't wrapped
+        self.assertNotIn('unquoted="True"', compiled)
+
+    def test_unquoted_cvars_preserved_in_compilation(self):
+        """Unquoted c-vars attrs should stay unquoted"""
+        compiled = get_compiled('<c-vars enabled=True count=42 />')
+        self.assertIn('enabled=True', compiled)
+        self.assertIn('count=42', compiled)
+        self.assertNotIn('enabled="True"', compiled)
+        self.assertNotIn('count="42"', compiled)

--- a/django_cotton/tests/unit/test_tag_parser.py
+++ b/django_cotton/tests/unit/test_tag_parser.py
@@ -110,3 +110,34 @@ class TagParserTests(unittest.TestCase):
         self.assertIn("active", result.empty_attrs)
         self.assertIn("disabled", result.empty_attrs)
 
+    def test_parse_component_tag_unquoted_values(self):
+        """Unquoted values should be preserved without quotes"""
+        result = parse_component_tag('cotton test_comp count=5 disabled=True')
+        self.assertEqual(result.attrs["count"], '5')  # No quotes
+        self.assertEqual(result.attrs["disabled"], 'True')  # No quotes
+
+    def test_parse_component_tag_quoted_values_have_quotes(self):
+        """Quoted values should retain quotes in parsed result"""
+        result = parse_component_tag('cotton test_comp count="5" disabled="True"')
+        self.assertEqual(result.attrs["count"], '"5"')  # Has quotes
+        self.assertEqual(result.attrs["disabled"], '"True"')  # Has quotes
+
+    def test_parse_component_tag_mixed_quoted_unquoted(self):
+        """Mix of quoted and unquoted should preserve each correctly"""
+        result = parse_component_tag('cotton test_comp quoted="string" unquoted=True number=42')
+        self.assertEqual(result.attrs["quoted"], '"string"')  # Quoted
+        self.assertEqual(result.attrs["unquoted"], 'True')  # Unquoted
+        self.assertEqual(result.attrs["number"], '42')  # Unquoted
+
+    def test_parse_vars_tag_unquoted_values(self):
+        """Unquoted values in vars tag should be preserved without quotes"""
+        result = parse_vars_tag('cotton:vars enabled=True count=42')
+        self.assertEqual(result.attrs["enabled"], 'True')  # No quotes
+        self.assertEqual(result.attrs["count"], '42')  # No quotes
+
+    def test_parse_vars_tag_mixed_quoted_unquoted(self):
+        """Mix of quoted and unquoted in vars tag should preserve each correctly"""
+        result = parse_vars_tag('cotton:vars label="Hello" enabled=True')
+        self.assertEqual(result.attrs["label"], '"Hello"')  # Quoted
+        self.assertEqual(result.attrs["enabled"], 'True')  # Unquoted
+

--- a/docs/docs_project/docs_project/templates/components.html
+++ b/docs/docs_project/docs_project/templates/components.html
@@ -101,9 +101,30 @@
 
     <c-hr id="dynamic-attributes" />
 
-    <h2>4. Dynamic Attributes with ":"</h2>
+    <h2>4. Dynamic Attributes</h2>
 
-    <p>We saw how by default, all attributes that we pass to a component are treated as strings. If we want to pass HTML, we can use named slots. But what if we want to pass another data type like a template variable, boolean, integer, float, dictionary, list, dictionary?</p>
+    <p>We saw how by default, all attributes that we pass to a component are treated as strings. If we want to pass HTML, we can use named slots. But what if we want to pass another data type like a template variable, boolean, integer, float, dictionary, list?</p>
+
+    <p>Cotton supports two syntaxes for dynamic values:</p>
+
+    <c-ul>
+        <li><strong>Quoteless values</strong>: <code>attr=value</code> - for simple values without spaces (like native Django)</li>
+        <li><strong>Colon prefix</strong>: <code>:attr="value"</code> - works for any expression</li>
+    </c-ul>
+
+<c-snippet label="Quoteless syntax">{% cotton:verbatim %}{% verbatim %}
+<!-- Simple literals and variables -->
+<c-button enabled=True />
+<c-button enabled=False />
+<c-input value=my_variable />
+<c-counter start=42 />
+{% endverbatim %}{% endcotton:verbatim %}</c-snippet>
+
+<c-snippet label="Colon prefix (for complex expressions)">{% cotton:verbatim %}{% verbatim %}
+<!-- Required for expressions with spaces/quotes -->
+<c-select :options="['yes', 'no', 'maybe']" />
+<c-card :config="{'open': True}" />
+{% endverbatim %}{% endcotton:verbatim %}</c-snippet>
 
     <h3>Passing objects from context</h3>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django-cotton"
-version = "2.5.1"
+version = "2.6.0"
 description = "Enabling Modern UI Composition in Django."
 authors = [ "Will Abbott <willabb83@gmail.com>",]
 license = "MIT"


### PR DESCRIPTION
For a while now I have wanted to support DTL way of simple dynamic attribute values:

Currently:

```html
<c-some-component :required="True" />
```

With support:

```html
<c-some-component required=True />
```

The current version will remain fully supported and is still the required approach when dealing with more complex dynamic attributes like string literals with nested quotes and spaces.