### PR TITLE
fix: render_component now supports nested folder paths

### DIFF
--- a/django_cotton/tests/integration/test_render_component_helper.py
+++ b/django_cotton/tests/integration/test_render_component_helper.py
@@ -137,3 +137,49 @@ class TestRenderComponentHelper(CottonTestCase):
         self.assertIn('hx-target="#result"', rendered)
 
         self.assertNotIn("label=", rendered)
+
+    def test_render_component_with_nested_folder_path(self):
+        """Test that dots in component name create folder nesting (e.g., settings.user-row -> cotton/settings/user_row.html)"""
+        self.create_template(
+            "cotton/settings/user_row.html",
+            """
+            <c-vars user_id username is_active />
+            <tr id="user-{{ user_id }}">
+                <td>{{ username }}</td>
+                <td>{% if is_active %}Active{% else %}Inactive{% endif %}</td>
+            </tr>
+            """,
+        )
+
+        rendered = render_component(
+            self.request,
+            "settings.user-row",
+            {"user_id": 42, "username": "johndoe", "is_active": True},
+        )
+
+        self.assertIn('id="user-42"', rendered)
+        self.assertIn("johndoe", rendered)
+        self.assertIn("Active", rendered)
+
+    def test_render_component_with_deeply_nested_path(self):
+        """Test deeply nested component paths (e.g., ui.forms.text-input -> cotton/ui/forms/text_input.html)"""
+        self.create_template(
+            "cotton/ui/forms/text_input.html",
+            """
+            <c-vars name label value="" />
+            <div class="form-group">
+                <label for="{{ name }}">{{ label }}</label>
+                <input type="text" id="{{ name }}" name="{{ name }}" value="{{ value }}" />
+            </div>
+            """,
+        )
+
+        rendered = render_component(
+            self.request,
+            "ui.forms.text-input",
+            {"name": "email", "label": "Email Address", "value": "test@example.com"},
+        )
+
+        self.assertIn('id="email"', rendered)
+        self.assertIn("Email Address", rendered)
+        self.assertIn('value="test@example.com"', rendered)


### PR DESCRIPTION
The render_component helper was converting dots to hyphens which broke nested component paths:

Before: 'settings.user-row' -> looked for 'cotton/settings_user_row.html'
After:  'settings.user-row' -> looks for 'cotton/settings/user_row.html'

Changes:
- Removed the line that replaced dots with hyphens in component names
- Added two new tests for nested folder paths

This enables using render_component for HTMX partials with components organized in subdirectories.