### PR TITLE
perf: cache repeatedly created objects during component rendering

### DIFF
--- a/django_cotton/templatetags/__init__.py
+++ b/django_cotton/templatetags/__init__.py
@@ -114,58 +114,83 @@ class UnprocessableDynamicAttr(Exception):
 
 
 class DynamicAttr:
+    _template_cache: dict[str, Template] = {}
+    _literal_cache: dict[str, Any] = {}
+    _variable_cache: dict[str, Variable] = {}
+
+    _MISSING = object()
+
     def __init__(self, value: str, is_cvar=False):
         self.value = value
         self._is_cvar = is_cvar
-        self._resolved_value = None
+        self._resolved_value = self._MISSING
+
+    def _resolve_variable(self, value, context):
+        var = self._variable_cache.get(value)
+        if var is None:
+            var = Variable(value)
+            self._variable_cache[value] = var
+        resolved = var.resolve(context)
+        return resolved.attrs_dict() if isinstance(resolved, Attrs) else resolved
+
+    def _resolve_template(self, value, context):
+        mini = self._template_cache.get(value)
+        if mini is None:
+            mini = Template(value)
+            self._template_cache[value] = mini
+        rendered = mini.render(context)
+        if rendered == value:
+            return self._MISSING
+        try:
+            return ast.literal_eval(rendered)
+        except (ValueError, SyntaxError):
+            return rendered
+
+    def _resolve_literal(self, value):
+        cached = self._literal_cache.get(value, self._MISSING)
+        if cached is not self._MISSING:
+            return cached
+        result = ast.literal_eval(value)
+        self._literal_cache[value] = result
+        return result
 
     def resolve(self, context: Context) -> Any:
-        if self._resolved_value is not None:
+        if self._resolved_value is not self._MISSING:
             return self._resolved_value
 
-        resolvers = [
-            self._resolve_as_variable,
-            self._resolve_as_boolean,
-            self._resolve_as_template,
-            self._resolve_as_literal,
-        ]
+        value = self.value
 
-        for resolver in resolvers:
+        if value == "":
+            self._resolved_value = True
+            return True
+
+        cached = self._literal_cache.get(value, self._MISSING)
+        if cached is not self._MISSING:
+            self._resolved_value = cached
+            return cached
+
+        try:
+            self._resolved_value = self._resolve_variable(value, context)
+            return self._resolved_value
+        except (VariableDoesNotExist, TemplateSyntaxError):
+            pass
+
+        if "{{" in value or "{%" in value:
             try:
-                # noinspection PyArgumentList
-                self._resolved_value = resolver(context)
-                return self._resolved_value
-            except (VariableDoesNotExist, TemplateSyntaxError, ValueError, SyntaxError):
-                continue
+                result = self._resolve_template(value, context)
+                if result is not self._MISSING:
+                    self._resolved_value = result
+                    return result
+            except Exception:
+                pass
+
+        try:
+            self._resolved_value = self._resolve_literal(value)
+            return self._resolved_value
+        except (ValueError, SyntaxError):
+            pass
 
         raise UnprocessableDynamicAttr
-
-    def _resolve_as_variable(self, context):
-        value = Variable(self.value).resolve(context)
-        if isinstance(value, Attrs):
-            return value.attrs_dict()
-        return value
-
-    def _resolve_as_boolean(self, _):
-        if self.value == "":
-            return True
-        raise ValueError
-
-    def _resolve_as_template(self, context):
-        template = Template(self.value)
-        rendered_value = template.render(context)
-        if rendered_value != self.value:
-            # Try to evaluate the rendered value as a Python literal
-            # This handles cases like :attr="{'key': {{ var }}}" where {{ var }} is rendered first
-            try:
-                return ast.literal_eval(rendered_value)
-            except (ValueError, SyntaxError):
-                # Not a valid literal, return as string
-                return rendered_value
-        raise TemplateSyntaxError
-
-    def _resolve_as_literal(self, _):
-        return ast.literal_eval(self.value)
 
 
 class Attrs(Mapping):

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -18,6 +18,8 @@ register = Library()
 
 
 class CottonComponentNode(Node):
+    _mini_template_cache: dict[tuple, Template] = {}
+
     def __init__(self, component_name, nodelist, attrs, only, loaded_libraries=None):
         self.component_name = component_name
         self.nodelist = nodelist
@@ -178,9 +180,13 @@ class CottonComponentNode(Node):
         """Evaluate template syntax in a value if present, otherwise return as-is."""
         if isinstance(value, str) and ("{{" in value or "{%" in value):
             try:
-                load_tags = [f"{{% load {lib} %}}" for lib in self.loaded_libraries]
-                template_str = "".join(load_tags) + value
-                mini_template = Template(template_str)
+                cache_key = (value, tuple(self.loaded_libraries))
+                mini_template = self._mini_template_cache.get(cache_key)
+                if mini_template is None:
+                    load_tags = [f"{{% load {lib} %}}" for lib in self.loaded_libraries]
+                    template_str = "".join(load_tags) + value
+                    mini_template = Template(template_str)
+                    self._mini_template_cache[cache_key] = mini_template
                 return mini_template.render(context)
             except Exception:
                 return value

--- a/django_cotton/templatetags/_vars.py
+++ b/django_cotton/templatetags/_vars.py
@@ -17,6 +17,8 @@ from django_cotton.utils import get_cotton_data
 
 
 class CottonVarsNode(Node):
+    _mini_template_cache: dict[tuple, Template] = {}
+
     def __init__(self, var_dict, empty_vars: List, loaded_libraries: List[str]):
         self.var_dict = var_dict
         self.empty_vars = empty_vars
@@ -56,11 +58,13 @@ class CottonVarsNode(Node):
                         # If value contains template tags or variables, evaluate it at render time
                         if isinstance(value, str) and ("{{" in value or "{%" in value):
                             try:
-                                # Prepend {% load %} tags for libraries that were loaded at parse time
-                                load_tags = [f"{{% load {lib} %}}" for lib in self.loaded_libraries]
-                                template_str = "".join(load_tags) + value
-
-                                mini_template = Template(template_str)
+                                cache_key = (value, tuple(self.loaded_libraries))
+                                mini_template = self._mini_template_cache.get(cache_key)
+                                if mini_template is None:
+                                    load_tags = [f"{{% load {lib} %}}" for lib in self.loaded_libraries]
+                                    template_str = "".join(load_tags) + value
+                                    mini_template = Template(template_str)
+                                    self._mini_template_cache[cache_key] = mini_template
                                 rendered_value = mini_template.render(context)
                                 # Convert hyphens to underscores for template accessibility
                                 accessible_key = key_to_exclude.replace("-", "_")


### PR DESCRIPTION
## Problem

When rendering components, Cotton recreates `Template`, `Variable`, and `ast.literal_eval` objects from scratch on every render, even when the inputs are identical. These inputs come from template source code (attribute expressions, variable names, literal defaults), so they never change between renders.

I profiled a page rendering 50 table rows (~18 nested components each, 900 component renders total) with `cProfile`:

```
         514992 function calls (455632 primitive calls) in 0.164 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1651    0.004    0.000    0.008    0.000 django/template/base.py:871(__init__)        # Variable() created 1,651 times
     1951    0.005    0.000    0.010    0.000 ast.py:50(literal_eval)                      # literal_eval called 1,951 times
     1550    0.001    0.000    0.041    0.000 _component.py:182(_evaluate_template_value)  # Template() compiled 1,550 times
     3502    0.003    0.000    0.025    0.000 __init__.py:124(resolve)                      # DynamicAttr.resolve called 3,502 times
```

All of these produce identical results for the same inputs across renders.

## What this does

Caches these objects at the class level after first creation. The caches are keyed on source strings, so they're bounded by the project's template count, not by request volume. In practice they hold ~15-25 entries and use ~2 KB of memory.

Also restructures `DynamicAttr.resolve()` to break the resolution strategies into separate methods and uses a `_MISSING` sentinel instead of `None` checks so that falsy values like `False`, `0`, and `None` are cached correctly.

## Results

`render_load_test.py` shows no change since those benchmarks don't use dynamic attributes so the caches don't come into play.

I tested against a real component tree: 50 table rows, each nesting ~18 components with `:prop` bindings, `{{ }}` in attribute values, and `c-vars` with dynamic defaults:

```python
render_component(request, "features/application/rows", applications=apps[:1])  # warm

times = []
for _ in range(5):
    t0 = time.time()
    render_component(request, "features/application/rows", applications=apps)  # 50 rows
    times.append((time.time() - t0) * 1000)
```

Before: 149ms avg / After: 36ms avg, about 4x faster.

All 159 tests pass.