### PR TITLE
perf: move attribute resolution from render time to parse time

### DIFF
--- a/django_cotton/templatetags/__init__.py
+++ b/django_cotton/templatetags/__init__.py
@@ -143,6 +143,30 @@ def snapshot_parser_library(parser: Parser) -> Library:
     return active_library
 
 
+def compile_inline_template(value: str, active_library: Library | None = None) -> InlineTemplate:
+    """Compile a template fragment at parse time for later rendering.
+
+    Returns an InlineTemplate whose .render(context) can be called at render time
+    without re-lexing or re-parsing the template string.
+    """
+    engine = Engine.get_default()
+    origin = Origin(UNKNOWN_SOURCE)
+
+    if active_library is None:
+        nodelist = engine.from_string(value).nodelist
+    else:
+        lexer = DebugLexer(value) if engine.debug else Lexer(value)
+        parser = Parser(
+            lexer.tokenize(),
+            engine.template_libraries,
+            [active_library],
+            origin,
+        )
+        nodelist = parser.parse()
+
+    return InlineTemplate(value, nodelist, engine, origin=origin)
+
+
 def render_inline_template(value: str, context: Context, active_library: Library | None = None) -> str:
     """Render a template fragment with the caller template's active tag/filter scope."""
     if active_library is None:
@@ -283,6 +307,8 @@ class Attrs(Mapping):
         self._unprocessable.append(key)
 
     def exclude_unprocessable(self):
+        if not self._unprocessable:
+            return self._attrs
         return {k: v for k, v in self._attrs.items() if k not in self._unprocessable}
 
     def exclude_from_string_output(self, key):

--- a/django_cotton/templatetags/__init__.py
+++ b/django_cotton/templatetags/__init__.py
@@ -1,8 +1,7 @@
-import ast
 from collections.abc import Mapping
 from typing import Set, Any, Dict, List, Tuple
 
-from django.template import Variable, TemplateSyntaxError, Context, Library
+from django.template import Context, Library
 from django.template.base import (
     DebugLexer,
     Lexer,
@@ -10,7 +9,6 @@ from django.template.base import (
     Parser,
     Template,
     UNKNOWN_SOURCE,
-    VariableDoesNotExist,
 )
 from django.template.engine import Engine
 from django.utils.safestring import mark_safe
@@ -197,66 +195,6 @@ def render_inline_template(value: str, context: Context, active_library: Library
 
 class UnprocessableDynamicAttr(Exception):
     pass
-
-
-class DynamicAttr:
-    def __init__(
-        self,
-        value: str,
-        is_cvar: bool = False,
-        active_library: Library | None = None,
-    ):
-        self.value = value
-        self._is_cvar = is_cvar
-        self._resolved_value = None
-        self.active_library = active_library
-
-    def resolve(self, context: Context) -> Any:
-        if self._resolved_value is not None:
-            return self._resolved_value
-
-        resolvers = [
-            self._resolve_as_variable,
-            self._resolve_as_boolean,
-            self._resolve_as_template,
-            self._resolve_as_literal,
-        ]
-
-        for resolver in resolvers:
-            try:
-                # noinspection PyArgumentList
-                self._resolved_value = resolver(context)
-                return self._resolved_value
-            except (VariableDoesNotExist, TemplateSyntaxError, ValueError, SyntaxError):
-                continue
-
-        raise UnprocessableDynamicAttr
-
-    def _resolve_as_variable(self, context):
-        value = Variable(self.value).resolve(context)
-        if isinstance(value, Attrs):
-            return value.attrs_dict()
-        return value
-
-    def _resolve_as_boolean(self, _):
-        if self.value == "":
-            return True
-        raise ValueError
-
-    def _resolve_as_template(self, context):
-        rendered_value = render_inline_template(self.value, context, self.active_library)
-        if rendered_value != self.value:
-            # Try to evaluate the rendered value as a Python literal
-            # This handles cases like :attr="{'key': {{ var }}}" where {{ var }} is rendered first
-            try:
-                return ast.literal_eval(rendered_value)
-            except (ValueError, SyntaxError):
-                # Not a valid literal, return as string
-                return rendered_value
-        raise TemplateSyntaxError
-
-    def _resolve_as_literal(self, _):
-        return ast.literal_eval(self.value)
 
 
 class Attrs(Mapping):

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -67,13 +67,13 @@ class PreparedValue:
 
         try:
             self._variable = Variable(raw)
-        except Exception:
+        except (TypeError, TemplateSyntaxError):
             pass  # Not a valid variable expression, will try other resolvers
 
         if "{{" in raw or "{%" in raw:
             try:
                 self._template = compile_inline_template(raw, active_library)
-            except Exception:
+            except TemplateSyntaxError:
                 pass  # Not a valid template expression, will try literal
 
         try:

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -1,10 +1,15 @@
+import ast
 import functools
-from typing import Union
+from enum import IntEnum
+from typing import Any, NamedTuple, Union
 
 from django.conf import settings
 from django.template import Library, TemplateDoesNotExist
 from django.template.base import (
     Node,
+    Variable,
+    VariableDoesNotExist,
+    TemplateSyntaxError,
 )
 from django.template.context import Context, RequestContext
 from django.template.loader import get_template
@@ -13,17 +18,156 @@ from django_cotton.utils import get_cotton_data
 from django_cotton.exceptions import CottonIncompleteDynamicComponentError
 from django_cotton.templatetags import (
     Attrs,
-    DynamicAttr,
+    InlineTemplate,
     UnprocessableDynamicAttr,
-    render_inline_template,
+    compile_inline_template,
     snapshot_parser_library,
     strip_quotes_with_status,
 )
 
 register = Library()
 
+_MISSING = object()
+
+
+class AttrKind(IntEnum):
+    BOOLEAN = 0
+    ESCAPED = 1      # :: prefix (Alpine.js colon escaping) or quoted value with {{ }}/{% %}
+    DYNAMIC = 2      # : prefix — explicit dynamic binding
+    UNQUOTED = 3     # no quotes — treated as dynamic, falls back to string literal
+    STATIC = 4
+
+
+class PreparedAttr(NamedTuple):
+    key: str
+    kind: AttrKind
+    value: Any
+    compiled: Any
+
+
+class PreparedValue:
+    """Pre-compiled resolution chain for a dynamic attribute value.
+
+    Created once at template parse time. At render time, resolve() tries
+    each pre-built resolver in order: variable lookup, template render
+    (with optional literal_eval of the result), then literal eval of the
+    raw value.
+    """
+
+    __slots__ = ("raw", "_variable", "_template", "_literal")
+
+    def __init__(self, raw: Any, *, active_library: Library | None = None) -> None:
+        self.raw = raw
+        self._variable = None
+        self._template = None
+        self._literal = _MISSING
+
+        if not isinstance(raw, str) or not raw:
+            return
+
+        try:
+            self._variable = Variable(raw)
+        except Exception:
+            pass  # Not a valid variable expression, will try other resolvers
+
+        if "{{" in raw or "{%" in raw:
+            try:
+                self._template = compile_inline_template(raw, active_library)
+            except Exception:
+                pass  # Not a valid template expression, will try literal
+
+        try:
+            self._literal = ast.literal_eval(raw)
+        except (ValueError, SyntaxError):
+            pass  # Not a Python literal, will raise UnprocessableDynamicAttr at resolve time
+
+    def resolve(self, context: Context) -> Any:
+        """Resolve the attribute value against a template context.
+
+        Tries each pre-built resolver in order: empty string (boolean True),
+        variable lookup, template render, then literal eval. Returns the
+        first successful result or raises UnprocessableDynamicAttr.
+        """
+        if self.raw == "":
+            return True
+
+        if self._variable is not None:
+            try:
+                resolved = self._variable.resolve(context)
+                if isinstance(resolved, Attrs):
+                    return resolved.attrs_dict()
+                return resolved
+            except (VariableDoesNotExist, TemplateSyntaxError):
+                pass
+
+        if self._template is not None:
+            try:
+                rendered = self._template.render(context)
+                if rendered != self.raw:
+                    try:
+                        return ast.literal_eval(rendered)
+                    except (ValueError, SyntaxError):
+                        return rendered
+            except Exception:
+                pass  # Template render failed, fall through to literal resolution
+
+        if self._literal is not _MISSING:
+            return self._literal
+
+        raise UnprocessableDynamicAttr
+
+
+def _try_compile_template(value: Any, active_library: Library | None) -> InlineTemplate | None:
+    """Try to compile a template from a value containing {{ }} or {% %}.
+    Returns the compiled InlineTemplate or None if compilation fails or value
+    has no template syntax.
+    """
+    if isinstance(value, str) and ("{{" in value or "{%" in value):
+        try:
+            return compile_inline_template(value, active_library)
+        except Exception:
+            pass
+    return None
+
+
+def _prepare_attrs(attrs: dict[str, Any], active_library: Library | None) -> list[PreparedAttr]:
+    """Pre-classify and pre-compile component attributes at parse time.
+
+    Returns a list of PreparedAttr tuples with pre-built Variable, Template,
+    and literal objects so that render() only needs to call resolve/render
+    on them without recreating anything.
+    """
+    prepared = []
+
+    for key, raw_value in attrs.items():
+        value, was_quoted = strip_quotes_with_status(raw_value)
+
+        if value is True:
+            prepared.append(PreparedAttr(key, AttrKind.BOOLEAN, True, None))
+
+        elif key.startswith("::"):
+            compiled = _try_compile_template(value, active_library)
+            prepared.append(PreparedAttr(key[1:], AttrKind.ESCAPED, value, compiled))
+
+        elif key.startswith(":"):
+            pv = PreparedValue(value, active_library=active_library)
+            prepared.append(PreparedAttr(key[1:], AttrKind.DYNAMIC, value, pv))
+
+        elif not was_quoted and isinstance(value, str) and value:
+            pv = PreparedValue(value, active_library=active_library)
+            prepared.append(PreparedAttr(key, AttrKind.UNQUOTED, value, pv))
+
+        else:
+            compiled = _try_compile_template(value, active_library)
+            kind = AttrKind.ESCAPED if compiled else AttrKind.STATIC
+            prepared.append(PreparedAttr(key, kind, value, compiled))
+
+    return prepared
+
 
 class CottonComponentNode(Node):
+    _vars_node_cache: dict[int, list[Node]] = {}
+
     def __init__(
         self,
         component_name,
@@ -38,6 +182,7 @@ class CottonComponentNode(Node):
         self.template_cache = {}
         self.only = only
         self.active_library = active_library
+        self._prepared_attrs = _prepare_attrs(attrs, active_library)
 
     def render(self, context):
         cotton_data = get_cotton_data(context)
@@ -50,41 +195,38 @@ class CottonComponentNode(Node):
         }
         cotton_data["stack"].append(component_data)
 
-        # Process simple attributes and boolean attributes
-        for key, value in self.attrs.items():
-            value, was_quoted = strip_quotes_with_status(value)
-            if value is True:  # Boolean attribute (no value, e.g. `disabled`)
-                component_data["attrs"][key] = True
-            elif key.startswith("::"):  # Escaping 1 colon e.g for shorthand alpine
-                key = key[1:]
-                component_data["attrs"][key] = self._evaluate_template_value(value, context)
-            elif key.startswith(":"):  # Explicit dynamic attribute with colon prefix
-                key = key[1:]
+        for attr in self._prepared_attrs:
+            # Boolean attribute (no value, e.g. `disabled`)
+            if attr.kind == AttrKind.BOOLEAN:
+                component_data["attrs"][attr.key] = True
+
+            # :: prefix (Alpine.js colon escaping) or quoted value with {{ }}/{% %}
+            elif attr.kind == AttrKind.ESCAPED:
+                component_data["attrs"][attr.key] = (
+                    attr.compiled.render(context) if attr.compiled else attr.value
+                )
+
+            # : prefix — explicit dynamic binding
+            elif attr.kind == AttrKind.DYNAMIC:
                 try:
-                    resolved_value = DynamicAttr(
-                        value, active_library=self.active_library
-                    ).resolve(context)
-                except UnprocessableDynamicAttr:
-                    component_data["attrs"].unprocessable(key)
-                else:
-                    # Handle ":attrs" specially
-                    if key == "attrs":
-                        component_data["attrs"].dict.update(resolved_value)
+                    resolved = attr.compiled.resolve(context)
+                    if attr.key == "attrs":
+                        component_data["attrs"].dict.update(resolved)
                     else:
-                        component_data["attrs"][key] = resolved_value
-            elif not was_quoted and isinstance(value, str) and value:
-                # Unquoted value - treat as dynamic (like native DTL behavior)
-                try:
-                    resolved_value = DynamicAttr(
-                        value, active_library=self.active_library
-                    ).resolve(context)
-                    component_data["attrs"][key] = resolved_value
+                        component_data["attrs"][attr.key] = resolved
                 except UnprocessableDynamicAttr:
-                    # Fall back to string literal (Django's permissive behavior)
-                    component_data["attrs"][key] = value
+                    component_data["attrs"].unprocessable(attr.key)
+
+            # No quotes — treated as dynamic, falls back to string literal
+            elif attr.kind == AttrKind.UNQUOTED:
+                try:
+                    component_data["attrs"][attr.key] = attr.compiled.resolve(context)
+                except Exception:
+                    component_data["attrs"][attr.key] = attr.value
+
+            # Plain static value
             else:
-                # Static attribute (quoted) - check if it contains template syntax
-                component_data["attrs"][key] = self._evaluate_template_value(value, context)
+                component_data["attrs"][attr.key] = attr.value
 
         # Render the nodelist to process any slot tags and vars
         default_slot = self.nodelist.render(context)
@@ -180,25 +322,18 @@ class CottonComponentNode(Node):
         """Extract vars from any CottonVarsNode instances in the template."""
         from django_cotton.templatetags._vars import CottonVarsNode
 
-        vars = {}
+        template_id = id(template)
+        vars_nodes = self._vars_node_cache.get(template_id)
+        if vars_nodes is None:
+            vars_nodes = [n for n in template.nodelist if isinstance(n, CottonVarsNode)]
+            self._vars_node_cache[template_id] = vars_nodes
 
-        # Walk the template nodelist to find CottonVarsNode instances
-        for node in template.nodelist:
-            if isinstance(node, CottonVarsNode):
-                # Extract vars from this node
-                node_vars = node.extract_vars(context, attrs, slots)
-                vars.update(node_vars)
+        vars = {}
+        for node in vars_nodes:
+            node_vars = node.extract_vars(context, attrs, slots)
+            vars.update(node_vars)
 
         return vars
-
-    def _evaluate_template_value(self, value, context):
-        """Evaluate template syntax in a value if present, otherwise return as-is."""
-        if isinstance(value, str) and ("{{" in value or "{%" in value):
-            try:
-                return render_inline_template(value, context, self.active_library)
-            except Exception:
-                return value
-        return value
 
     @staticmethod
     @functools.lru_cache(maxsize=400)

--- a/django_cotton/templatetags/_vars.py
+++ b/django_cotton/templatetags/_vars.py
@@ -1,89 +1,102 @@
-from typing import List
+from typing import Any, NamedTuple
 
 from django.template import Library
 from django.template.base import Node
 
 from django_cotton.templatetags import (
-    DynamicAttr,
-    UnprocessableDynamicAttr,
     Attrs,
-    render_inline_template,
     snapshot_parser_library,
     strip_quotes_with_status,
 )
+from django_cotton.templatetags._component import AttrKind, PreparedValue, _try_compile_template
 from django_cotton.utils import get_cotton_data
+
+
+class PreparedVar(NamedTuple):
+    key: str
+    exclude_key: str
+    accessible_key: str
+    kind: AttrKind
+    value: Any
+    compiled: Any
 
 
 class CottonVarsNode(Node):
     def __init__(
         self,
-        var_dict,
-        empty_vars: List,
-        active_library: Library | None,
+        var_dict: dict[str, Any],
+        empty_vars: list[str],
+        active_library: Library | None = None,
     ):
-        self.var_dict = var_dict
         self.empty_vars = empty_vars
         self.active_library = active_library
 
-    def extract_vars(self, context, attrs, slots):
+        self._prepared_vars = []
+
+        for key, raw_value in var_dict.items():
+            value, was_quoted = strip_quotes_with_status(raw_value)
+
+            if key.startswith(":"):
+                exclude_key = key[1:]
+                accessible_key = exclude_key.replace("-", "_")
+                pv = PreparedValue(value, active_library=active_library)
+                self._prepared_vars.append(PreparedVar(
+                    key, exclude_key, accessible_key, AttrKind.DYNAMIC, value, pv,
+                ))
+
+            elif not was_quoted and isinstance(value, str) and value:
+                accessible_key = key.replace("-", "_")
+                pv = PreparedValue(value, active_library=active_library)
+                self._prepared_vars.append(PreparedVar(
+                    key, key, accessible_key, AttrKind.UNQUOTED, value, pv,
+                ))
+
+            else:
+                accessible_key = key.replace("-", "_")
+                compiled = _try_compile_template(value, active_library)
+                kind = AttrKind.ESCAPED if compiled else AttrKind.STATIC
+                self._prepared_vars.append(PreparedVar(
+                    key, key, accessible_key, kind, value, compiled,
+                ))
+
+    def extract_vars(self, context: "Context", attrs: Attrs, slots: dict[str, str]) -> dict[str, Any]:
         """Extract and process vars, returning a dict of resolved values."""
         vars = {}
 
-        for key, raw_value in self.var_dict.items():
-            key_to_exclude = key
-            value, was_quoted = strip_quotes_with_status(raw_value)
+        for var in self._prepared_vars:
+            attrs.exclude_from_string_output(var.exclude_key)
 
-            if key not in attrs.exclude_unprocessable():
-                if key.startswith(":"):
-                    # Explicit dynamic attribute with colon prefix
-                    key_to_exclude = key[1:]
-                    if key_to_exclude not in slots:
-                        try:
-                            # Convert hyphens to underscores for template accessibility
-                            accessible_key = key_to_exclude.replace("-", "_")
-                            vars[accessible_key] = DynamicAttr(
-                                value,
-                                is_cvar=True,
-                                active_library=self.active_library,
-                            ).resolve(context)
-                        except UnprocessableDynamicAttr:
-                            pass
-                elif not was_quoted and isinstance(value, str) and value:
-                    # Unquoted value - treat as dynamic (like native DTL behavior)
-                    if key not in slots:
-                        try:
-                            accessible_key = key.replace("-", "_")
-                            vars[accessible_key] = DynamicAttr(
-                                value,
-                                is_cvar=True,
-                                active_library=self.active_library,
-                            ).resolve(context)
-                        except UnprocessableDynamicAttr:
-                            # Fall back to string literal (Django's permissive behavior)
-                            vars[accessible_key] = value
-                else:
-                    # Static attribute (quoted) - check if it contains template syntax
-                    if key not in slots:
-                        # If value contains template tags or variables, evaluate it at render time
-                        if isinstance(value, str) and ("{{" in value or "{%" in value):
-                            try:
-                                rendered_value = render_inline_template(
-                                    value, context, self.active_library
-                                )
-                                # Convert hyphens to underscores for template accessibility
-                                accessible_key = key_to_exclude.replace("-", "_")
-                                vars[accessible_key] = rendered_value
-                            except Exception:
-                                # If rendering fails, fall back to the raw value
-                                # Convert hyphens to underscores for template accessibility
-                                accessible_key = key_to_exclude.replace("-", "_")
-                                vars[accessible_key] = value
-                        else:
-                            # Plain static value
-                            # Convert hyphens to underscores for template accessibility
-                            accessible_key = key_to_exclude.replace("-", "_")
-                            vars[accessible_key] = value
-            attrs.exclude_from_string_output(key_to_exclude)
+            # Parent already set this attr, skip the default
+            if var.key in attrs.exclude_unprocessable():
+                continue
+            # Slot content overrides the default
+            if var.exclude_key in slots:
+                continue
+
+            # : prefix — explicit dynamic binding
+            if var.kind == AttrKind.DYNAMIC:
+                try:
+                    vars[var.accessible_key] = var.compiled.resolve(context)
+                except Exception:
+                    pass  # Var couldn't be resolved, skip it
+
+            # No quotes — treated as dynamic, falls back to string literal
+            elif var.kind == AttrKind.UNQUOTED:
+                try:
+                    vars[var.accessible_key] = var.compiled.resolve(context)
+                except Exception:
+                    vars[var.accessible_key] = var.value
+
+            # Quoted value containing {{ }} or {% %} — render the template
+            elif var.kind == AttrKind.ESCAPED:
+                try:
+                    vars[var.accessible_key] = var.compiled.render(context) if var.compiled else var.value
+                except Exception:
+                    vars[var.accessible_key] = var.value
+
+            # Plain static value
+            else:
+                vars[var.accessible_key] = var.value
 
         # Process cvars without values
         for empty_var in self.empty_vars:


### PR DESCRIPTION
This is an alternative/experimental to #353 that takes a different approach. It moves the expensive work (Template compilation, Variable creation, literal_eval) from render time to parse time, so it only happens once per template compilation.

## What this does

Same pattern as Django's own Variable class: parse once at compile time, resolve cheaply at render time. No rendered output is cached. Two small bounded indexes exist for structural lookups (vars-node discovery and path generation), but the core approach is precompilation, not caching.

## How is this different from #353?

\#353 adds class-level caches that store objects after first creation. This PR does the same work at __init__ time instead, so the pre-built objects are just instance attributes on the node, like self.nodelist and self.component_name.

Both approaches produce identical output. This one is a bit faster (28ms vs 36ms on the same benchmark) because it moves more work to parse time, including the `strip_quotes_with_status` calls, attribute prefix checks, and template compilation.

## Results

`render_load_test.py` shows no change since those benchmarks don't use dynamic attributes.

Using the same test as #353, a real component tree with 50 table rows, each nesting ~18 components with `:prop` bindings, `{{ }}` in attribute values, and `c-vars` with dynamic defaults:

```python
render_component(request, "features/application/rows", applications=apps[:1])  # warm

times = []
for _ in range(10):
    t0 = time.time()
    render_component(request, "features/application/rows", applications=apps)  # 50 rows
    times.append((time.time() - t0) * 1000)
```

Before: 148ms avg
After: **28ms avg** (about 5.3x faster)

Some screens of this in running in a personal project of mine:

<img width="1232" height="321" alt="before" src="https://github.com/user-attachments/assets/91e1df30-fe78-49f8-84be-3dcfb245bb6a" />
<img width="1226" height="328" alt="after" src="https://github.com/user-attachments/assets/de3daf8b-9404-4b7e-8409-d10dfe7ae4aa" />

## Other thoughts

~~What version of Python typing does this project support? The https://github.com/wrabit/django-cotton/blob/main/pyproject.toml#L24C8-L24C9 file says >= 3.8, but I'm pretty sure there is type syntax being used in the project that are >= 3.9 and I _think_ possibly even => 3.10.~~ Just noticed CI tests are 3.10+. Should probably bump pyproject.toml's Python version eventually.