### PR TITLE
Update minimum Python version from 3.8 to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,5 @@ exclude = "/(\n    \\.git\n  | \\.mypy_cache\n  | \\\\.tox\n  | \\\\.venv\n  | _
 profile = "black"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4"
+python = ">=3.10,<4"
 django = ">=4.2,<7.0"


### PR DESCRIPTION
The test matrix has been 3.10+ for a while and Django 5.0+ requires it. The codebase also uses `X | Y` union type syntax which is 3.10+. This aligns the pyproject with what we actually support and test against.