### PR TITLE
Add future annotations for older Python compat, extend test matrix to 3.8/3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,21 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         django: ["4.2", "5.0", "5.1", "5.2", "6.0"]
         exclude:
           - { python: "3.13", django: "4.2" }
           - { python: "3.13", django: "5.0" }
           - { python: "3.10", django: "6.0" }
           - { python: "3.11", django: "6.0" }
+          - { python: "3.8", django: "5.0" }
+          - { python: "3.8", django: "5.1" }
+          - { python: "3.8", django: "5.2" }
+          - { python: "3.8", django: "6.0" }
+          - { python: "3.9", django: "5.0" }
+          - { python: "3.9", django: "5.1" }
+          - { python: "3.9", django: "5.2" }
+          - { python: "3.9", django: "6.0" }
 
     name: Tests - python ${{ matrix.python }} × django ${{ matrix.django }}
 

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -11,6 +11,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=on \
     PYTHONUNBUFFERED=1 \
     DEBIAN_FRONTEND=noninteractive
 
+# Install build dependencies for older Python versions
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory in the container
 WORKDIR /app
 

--- a/dev/example_project/pyproject.toml
+++ b/dev/example_project/pyproject.toml
@@ -9,5 +9,5 @@ description = "Development and test app for the django package."
 authors = ["Will Abbott <willabb83@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.10"
-Django = "^5.1"
+python = ">=3.8"
+Django = ">=4.2"

--- a/django_cotton/templatetags/__init__.py
+++ b/django_cotton/templatetags/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Set, Any, Dict, List, Tuple
 

--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import functools
 from enum import IntEnum

--- a/django_cotton/templatetags/_vars.py
+++ b/django_cotton/templatetags/_vars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, NamedTuple
 
 from django.template import Library, TemplateSyntaxError


### PR DESCRIPTION
Recent changes introduced `X | Y` union type syntax which requires Python 3.10+. Since we still currently support 3.8+ (Django 4.2 LTS), this adds `from __future__ import annotations`.

Also extends the CI test matrix to include Python 3.8 and 3.9 (Django 4.2 only), and adds gcc + libc6-dev to the test Dockerfile for `backports-zoneinfo` compilation on 3.8.