### PR TITLE
Fix HTML attribute injection in dynamic attributes (#361)

### DIFF
--- a/django_cotton/tests/integration/test_attributes.py
+++ b/django_cotton/tests/integration/test_attributes.py
@@ -977,3 +977,30 @@ class AttributeHandlingTests(CottonTestCase):
         with self.settings(ROOT_URLCONF=self.url_conf()):
             response = self.client.get("/view/")
             self.assertContains(response, "some_undefined_thing")
+
+
+class AttributeInjectionTests(CottonTestCase):
+    def test_dynamic_attr_escapes_quotes_in_attrs_output(self):
+        """Ensure dynamic attribute values with quotes are HTML-escaped in {{ attrs }} (#361)"""
+        self.create_template(
+            "cotton/injection_test.html",
+            '<input {{ attrs }} />',
+        )
+
+        self.create_template(
+            "injection_test_view.html",
+            '{% load cotton %}<c-injection-test :placeholder="payload" />',
+            "view/",
+            context={"payload": 'x" onmouseover="alert(1)'},
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/view/")
+            content = response.content.decode()
+            # The payload must NOT break out of the placeholder attribute.
+            # Unsafe output: placeholder="x" onmouseover="alert(1)"
+            # Safe output:   placeholder='x" onmouseover="alert(1)'
+            #            or: placeholder="x&quot; onmouseover=&quot;alert(1)"
+            self.assertNotIn('placeholder="x"', content)
+            # The whole payload must be contained in one attribute value
+            self.assertRegex(content, r'''placeholder=["']x.+alert\(1\)["']''')

--- a/django_cotton/utils.py
+++ b/django_cotton/utils.py
@@ -1,5 +1,7 @@
 import ast
 
+from django.utils.html import escape
+
 
 def eval_string(value):
     """
@@ -12,12 +14,25 @@ def eval_string(value):
 
 
 def ensure_quoted(value):
-    if isinstance(value, str):
-        if value.startswith('{"') and value.endswith("}"):
-            return f"'{value}'"  # use single quotes for json-like strings
-        elif value.startswith('"') and value.endswith('"'):
-            return value  # already quoted
-    return f'"{value}"'  # default to double quotes
+    value = str(value)
+    if value.startswith('"') and value.endswith('"'):
+        return value  # already quoted
+
+    has_double = '"' in value
+    has_single = "'" in value
+
+    if value.startswith('{"') and value.endswith("}"):
+        # JSON-like strings: use single quotes, escape inner single quotes
+        return "'" + value.replace("'", "&#x27;") + "'"
+    elif has_double and not has_single:
+        # Contains double quotes only: wrap with single quotes to avoid escaping
+        return "'" + value + "'"
+    elif has_double and has_single:
+        # Contains both: wrap with double quotes and escape inner double quotes
+        return '"' + value.replace('"', '&quot;') + '"'
+    else:
+        # No problematic quotes: default to double quotes
+        return '"' + value + '"'
 
 
 def get_cotton_data(context):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django-cotton"
-version = "2.7.0"
+version = "2.7.1"
 description = "Enabling Modern UI Composition in Django."
 authors = [ "Will Abbott <willabb83@gmail.com>",]
 license = "MIT"


### PR DESCRIPTION
Dynamic attribute values containing quotes could break out of the HTML attribute and inject arbitrary attributes (XSS). `ensure_quoted()` now picks the appropriate wrapping quote or escapes inner quotes when both types are present.

Closes #361