### PR TITLE
Fix intermittent loss of <c-vars> defaults in development

### DIFF
--- a/django_cotton/templatetags/_component.py
+++ b/django_cotton/templatetags/_component.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import functools
+import weakref
 from enum import IntEnum
 from typing import Any, NamedTuple
 
@@ -168,7 +169,13 @@ def _prepare_attrs(attrs: dict[str, Any], active_library: Library | None) -> lis
 
 
 class CottonComponentNode(Node):
-    _vars_node_cache: dict[int, list[Node]] = {}
+    # Keyed by the Template object itself (not id(template)). Using id() is unsafe
+    # because CPython reuses an address once an object is GC'd, so in development
+    # (no cached template loader) a freshly loaded template can collide with a
+    # collected one and inherit the wrong component's <c-vars> nodes. A
+    # WeakKeyDictionary keys on identity and auto-evicts when the template dies,
+    # so production keeps the cache while dev always re-extracts a new template.
+    _vars_node_cache: "weakref.WeakKeyDictionary[Any, list[Node]]" = weakref.WeakKeyDictionary()
 
     def __init__(
         self,
@@ -323,11 +330,10 @@ class CottonComponentNode(Node):
         """Extract vars from any CottonVarsNode instances in the template."""
         from django_cotton.templatetags._vars import CottonVarsNode
 
-        template_id = id(template)
-        vars_nodes = self._vars_node_cache.get(template_id)
+        vars_nodes = self._vars_node_cache.get(template)
         if vars_nodes is None:
             vars_nodes = [n for n in template.nodelist if isinstance(n, CottonVarsNode)]
-            self._vars_node_cache[template_id] = vars_nodes
+            self._vars_node_cache[template] = vars_nodes
 
         vars = {}
         for node in vars_nodes:

--- a/django_cotton/tests/regression/test_vars_node_cache_identity.py
+++ b/django_cotton/tests/regression/test_vars_node_cache_identity.py
@@ -1,0 +1,85 @@
+"""
+Regression tests for the <c-vars> node cache.
+
+2.7.0 introduced ``CottonComponentNode._vars_node_cache`` to avoid rescanning a
+component template's nodelist for ``CottonVarsNode`` instances on every render.
+It was keyed by ``id(template)``, which is only unique among objects alive at the
+same time: CPython reuses an address once an object is garbage collected. In
+development (DEBUG, no cached template loader) templates are recreated and
+discarded constantly, so a freshly loaded template could reuse the address of a
+collected, *different* template and inherit its cached vars-node list.
+
+When the wrong (or empty) list is returned, a component's ``<c-vars>`` defaults
+are never injected into the context. That surfaces as an intermittent
+``VariableDoesNotExist`` when the default is consumed as a *filter argument*
+(e.g. ``{{ size_classes|get_item:size }}``), because Django does not swallow
+missing-variable errors for filter arguments the way it does for a bare
+``{{ size }}``.
+
+The cache is now keyed by the template object itself via a ``WeakKeyDictionary``,
+which keys on identity (no address aliasing) and auto-evicts when the template
+dies.
+"""
+
+import weakref
+
+from django.test import override_settings
+
+from django_cotton.templatetags._component import CottonComponentNode
+from django_cotton.tests.utils import CottonTestCase
+
+
+@override_settings(ROOT_URLCONF="django_cotton.tests.urls")
+class VarsNodeCacheIdentityTests(CottonTestCase):
+    def test_cache_is_keyed_by_template_identity_not_id(self):
+        """The cache must key on the template object, not its id().
+
+        A plain dict keyed by ``id(template)`` is what allowed dev-reload
+        address reuse to cross-contaminate components; ``WeakKeyDictionary``
+        keys on identity and cannot be aliased.
+        """
+        self.assertIsInstance(
+            CottonComponentNode._vars_node_cache, weakref.WeakKeyDictionary
+        )
+
+    def test_cvars_default_applied_when_used_as_filter_argument(self):
+        """A <c-vars> default consumed as a filter argument must resolve.
+
+        This is the exact failure mode users hit: when the default is missing
+        from context it raises VariableDoesNotExist (filter args are not
+        forgiving), rather than silently rendering empty.
+        """
+        self.create_template(
+            "cotton/joined.html",
+            "<c-vars sep=\"-\" :items=\"['a', 'b', 'c']\" />{{ items|join:sep }}",
+        )
+        self.create_template("joined_view.html", "<c-joined />", "joined/")
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/joined/")
+            self.assertContains(response, "a-b-c")
+
+    def test_distinct_components_do_not_share_cached_vars(self):
+        """Two different component templates must each get their own vars.
+
+        Guards against any cache keying that could return one component's
+        vars-node list for another.
+        """
+        self.create_template(
+            "cotton/with_default.html",
+            '<c-vars greeting="hello" />{{ greeting }}',
+        )
+        self.create_template(
+            "cotton/other_default.html",
+            '<c-vars greeting="goodbye" />{{ greeting }}',
+        )
+        self.create_template(
+            "two_components_view.html",
+            "<c-with-default /> <c-other-default />",
+            "two/",
+        )
+
+        with self.settings(ROOT_URLCONF=self.url_conf()):
+            response = self.client.get("/two/")
+            self.assertContains(response, "hello")
+            self.assertContains(response, "goodbye")


### PR DESCRIPTION
## Summary
The vars-node cache added in 2.7.0 (`CottonComponentNode._vars_node_cache`) was keyed by `id(template)`. An `id()` is only unique among objects alive at the same time, and CPython reuses an address once an object is garbage collected.

In development (`DEBUG=True`, no cached template loader) templates are recreated and discarded constantly, so a freshly loaded template can reuse the address of a collected, different template and inherit its cached `<c-vars>` nodes. When that happens a component's `<c-vars>` defaults are never injected into the context.

It surfaces as an intermittent `VariableDoesNotExist` when a default is consumed as a filter argument, for example `{{ size_classes|get_item:size }}`, because Django does not swallow missing-variable errors for filter arguments the way it does for a bare `{{ size }}`. Production using the cached loader keeps one stable template object per file and was unaffected.

## Fix
Key the cache by the template object itself via a `weakref.WeakKeyDictionary`. It keys on identity so addresses cannot alias, and entries auto-evict when a template is collected, which also removes a latent unbounded-growth leak in the old `dict`.

## Tests
Adds `tests/regression/test_vars_node_cache_identity.py`: the cache is identity-keyed (fails on the old `id()` keying), a `<c-vars>` default used as a filter argument resolves, and distinct components do not share cached vars. Full suite passes (171).