### PR TITLE
Fix docs deploy: pin Railpack python to 3.13.13

### DIFF
--- a/docs/docs_project/railpack.json
+++ b/docs/docs_project/railpack.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.railpack.com",
   "packages": {
-    "node": "22"
+    "node": "22",
+    "python": "3.13.13"
   }
 }


### PR DESCRIPTION
Railway/Railpack deploys started failing with:

  mise ERROR Failed to install core:python@3.13.14: no precompiled python found

mise resolves the unpinned 3.13 to the newest patch (3.13.14), which has no precompiled standalone build published yet. Pinning the exact 3.13.13 (the version that built before) stops it chasing the newest patch.

Affects every main deploy, not just the mobile branch, so it's split out on its own.