### PR TITLE
docs: expand Django Cotton (VS Code) ecosystem entry with current features

### DIFF
--- a/docs/docs_project/docs_project/templates/ecosystem.html
+++ b/docs/docs_project/docs_project/templates/ecosystem.html
@@ -84,7 +84,7 @@
 
     <div class="not-prose mt-4 divide-y divide-zinc-200/70 dark:divide-zinc-700/50 border-y border-zinc-200/70 dark:border-zinc-700/50">
         <c-ecosystem-item name="Django Cotton (VS Code)" href="https://marketplace.visualstudio.com/items?itemName=twentyforty.django-cotton" author="twentyforty"
-            description="Autocompletion for component tags, go-to-definition, parameter intellisense from c-vars, and missing-component diagnostics.">
+            description="Autocomplete, hover docs and go-to-definition for components, props and slots, plus Find All References, unused-component detection, and diagnostics for missing components and slot-name typos.">
             <c-ecosystem-link href="https://marketplace.visualstudio.com/items?itemName=twentyforty.django-cotton">VS Code Marketplace</c-ecosystem-link>
             <c-ecosystem-link href="https://open-vsx.org/extension/twentyforty/django-cotton">Open VSX</c-ecosystem-link>
         </c-ecosystem-item>


### PR DESCRIPTION
## Summary

The [Django Cotton (VS Code)](https://marketplace.visualstudio.com/items?itemName=twentyforty.django-cotton) extension's ecosystem entry hasn't kept up with the extension itself - it now offers a fair bit more than "autocompletion, go-to-definition, parameter intellisense from c-vars, and missing-component diagnostics". This PR updates the one-line description on the Ecosystem page to reflect what's actually shipped today:

- Hover documentation for components and props
- Go-to-definition for props (to their `<c-vars>` declaration or first usage) and slot names
- Find All References, plus unused-component detection in the file explorer
- Support for the `c-vars`, `c-slot`, and `c-component` built-in directives
- A new diagnostic for `<c-slot name="...">` values that don't match anything the target component references (catches typos)

## Test plan

- Confirmed `ecosystem_item.html`'s description paragraph has no truncation/line-clamp styling, so the change is purely a copy update with no layout risk.
- Kept the new copy close in length to the other entries on the page (~24 words) per that component's own "one-line description" convention.